### PR TITLE
Fixed several inconsistencies with the RFC 3987, 8141 and 3986

### DIFF
--- a/modules/core/src/main/scala/ch/epfl/bluebrain/nexus/rdf/Iri.scala
+++ b/modules/core/src/main/scala/ch/epfl/bluebrain/nexus/rdf/Iri.scala
@@ -187,14 +187,14 @@ object Iri {
     * An absolute Url.
     *
     * @param scheme    the scheme part
-    * @param authority the authority part
+    * @param authority an optional authority part
     * @param path      the path part
     * @param query     an optional query part
     * @param fragment  an optional fragment part
     */
   final case class Url(
       scheme: Scheme,
-      authority: Authority,
+      authority: Option[Authority],
       path: Path,
       query: Option[Query],
       fragment: Option[Fragment]
@@ -243,18 +243,18 @@ object Iri {
       * Constructs an Url from its constituents.
       *
       * @param scheme    the scheme part
-      * @param authority the authority part
+      * @param authority an optional authority part
       * @param path      the path part
       * @param query     an optional query part
       * @param fragment  an optional fragment part
       */
     final def apply(
         scheme: Scheme,
-        authority: Authority,
+        authority: Option[Authority],
         path: Path,
         query: Option[Query],
         fragment: Option[Fragment]
-    ): Url = new Url(scheme, normalize(scheme, authority), path, query, fragment)
+    ): Url = new Url(scheme, authority.map(normalize(scheme, _)), path, query, fragment)
 
     /**
       * Attempt to construct a new Url from the argument validating the structure and the character encodings as per
@@ -286,7 +286,7 @@ object Iri {
         case Some(v) => "#" + v.show
         case _       => ""
       }
-      s"${url.scheme.show}://${url.authority.show}${p.show(url.path)}$query$fragment"
+      s"${url.scheme.show}:${url.authority.map("//" + _.show).getOrElse("")}${p.show(url.path)}$query$fragment"
     }
 
     final implicit val urlEq: Eq[Url] = Eq.fromUniversalEquals

--- a/modules/core/src/test/scala/ch/epfl/bluebrain/nexus/rdf/FragmentSpec.scala
+++ b/modules/core/src/test/scala/ch/epfl/bluebrain/nexus/rdf/FragmentSpec.scala
@@ -18,8 +18,8 @@ class FragmentSpec extends WordSpecLike with Matchers with Inspectors with Eithe
       Fragment(pct + ucs + delims + rest).right.value.value shouldEqual ucs + ucs + delims + rest
     }
 
-    "fail for empty" in {
-      Fragment("").left.value
+    "succeed for empty" in {
+      Fragment("").right.value
     }
 
     "show" in {

--- a/modules/core/src/test/scala/ch/epfl/bluebrain/nexus/rdf/HostSpec.scala
+++ b/modules/core/src/test/scala/ch/epfl/bluebrain/nexus/rdf/HostSpec.scala
@@ -144,10 +144,6 @@ class HostSpec extends WordSpecLike with Matchers with Inspectors with EitherVal
       Host.named(ucsUp + pct + delims + up).right.value.value shouldEqual (ucsLow + ucsLow + delims + low)
     }
 
-    "fail for empty" in {
-      Host.named("").left.value
-    }
-
     "show" in {
       Host.named(up).right.value.show shouldEqual low
     }

--- a/modules/core/src/test/scala/ch/epfl/bluebrain/nexus/rdf/QuerySpec.scala
+++ b/modules/core/src/test/scala/ch/epfl/bluebrain/nexus/rdf/QuerySpec.scala
@@ -13,6 +13,7 @@ class QuerySpec extends WordSpecLike with Matchers with Inspectors with EitherVa
     "be constructed successfully" in {
       // format: off
       val cases = List(
+        "" -> SortedMap.empty[String, SortedSet[String]],
         "a=b&a=b&a=c&a&b&b&b=c&d/&e?" -> SortedMap(
           "a" -> SortedSet("", "b", "c"),
           "b" -> SortedSet("", "c"),
@@ -31,7 +32,7 @@ class QuerySpec extends WordSpecLike with Matchers with Inspectors with EitherVa
       }
     }
     "fail to parse" in {
-      val cases = List("a==b", "a=b&", "a#", "a&&", "a=&b", "")
+      val cases = List("a==b", "a=b&", "a#", "a&&", "a=&b")
       forAll(cases) { str =>
         Query(str).left.value
       }

--- a/modules/core/src/test/scala/ch/epfl/bluebrain/nexus/rdf/UrlSpec.scala
+++ b/modules/core/src/test/scala/ch/epfl/bluebrain/nexus/rdf/UrlSpec.scala
@@ -12,12 +12,17 @@ class UrlSpec extends WordSpecLike with Matchers with Inspectors with EitherValu
       val cases = List(
         "hTtps://me:me@hOst:443/a/b?a&e=f&b=c#frag"   -> "https://me:me@host/a/b?a&b=c&e=f#frag",
         "hTtps://me:me@hOst#frag"                     -> "https://me:me@host#frag",
+        "hTtps://me:me@hOst?"                         -> "https://me:me@host?",
         "hTtp://hOst%C2%A3:80/a%C2%A3/b%C3%86c//:://" -> "http://host£/a£/bÆc//:://",
-        "hTtp://1.2.3.4:80/a%C2%A3/b%C3%86c//:://"    -> "http://1.2.3.4/a£/bÆc//:://"
+        "hTtp://1.2.3.4:80/a%C2%A3/b%C3%86c//:://"    -> "http://1.2.3.4/a£/bÆc//:://",
+        "hTtp://1.2.3.4:80/a%C2%A3/b%C3%86c//:://"    -> "http://1.2.3.4/a£/bÆc//:://",
+        "http://google.com/#"                         -> "http://google.com/#",
+        "FiLe:///bin/bash"                            -> "file:///bin/bash",
+        "FiLe:/bin/bash"                              -> "file:/bin/bash",
+        "MailtO:test@example.com"                     -> "mailto:test@example.com"
       )
       forAll(cases) {
-        case (in, expected) =>
-          Url(in).right.value.show shouldEqual expected
+        case (in, expected) => Url(in).right.value.show shouldEqual expected
       }
     }
     val withHash = Iri.absolute("hTtp://1.2.3.4:80/a%C2%A3/b%C3%86c//:://#hash").right

--- a/modules/core/src/test/scala/ch/epfl/bluebrain/nexus/rdf/UrnSpec.scala
+++ b/modules/core/src/test/scala/ch/epfl/bluebrain/nexus/rdf/UrnSpec.scala
@@ -12,18 +12,26 @@ class UrnSpec extends WordSpecLike with Matchers with Inspectors with EitherValu
       // format: off
       val cases = List(
         "urn:uUid:6e8bc430-9c3a-11d9-9669-0800200c9a66"           -> "urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66",
-        "urn:example:a%C2%A3/b%C3%86c//:://?=a=b"                 -> "urn:example:a£/bÆc//:://?=a=b",
+        "urn:example:a%C2%A3/b%C3%86c//:://?=a=b#"                 -> "urn:example:a£/bÆc//:://?=a=b#",
         "urn:lex:eu:council:directive:2010-03-09;2010-19-UE"      -> "urn:lex:eu:council:directive:2010-03-09;2010-19-UE",
         "urn:Example:weather?=op=map&lat=39.56&lon=-104.85#test"  -> "urn:example:weather?=lat=39.56&lon=-104.85&op=map#test",
         "urn:examp-lE:foo-bar-baz-qux?+CCResolve:cc=uk"           -> "urn:examp-le:foo-bar-baz-qux?+CCResolve:cc=uk",
         "urn:examp-lE:foo-bar-baz-qux?=a=b?+CCResolve:cc=uk"      -> "urn:examp-le:foo-bar-baz-qux?+CCResolve:cc=uk?=a=b",
         "urn:examp-lE:foo-bar-baz-qux?+CCResolve:cc=uk?=a=b"      -> "urn:examp-le:foo-bar-baz-qux?+CCResolve:cc=uk?=a=b",
         "urn:examp-lE:foo-bar-baz-qux?+CCResolve:cc=uk?=a=b#hash" -> "urn:examp-le:foo-bar-baz-qux?+CCResolve:cc=uk?=a=b#hash"
+
       )
       // format: on
       forAll(cases) {
         case (in, expected) =>
           Urn(in).right.value.show shouldEqual expected
+      }
+    }
+
+    "fail to parse" in {
+      val fail = List("urn:example:some/path/?=")
+      forAll(fail) { str =>
+        Urn(str).left.value
       }
     }
 


### PR DESCRIPTION
- A URN and a URL can have empty fragments
- A URL can have empty query parameter
- A URN cannot have empty query parameter
- A URL have an optional authority
- A URL also defines `path-absolute`, `path-rootless` and `path-empty`
- A host can be empty

Fixes #12 (and others which do not have issues related)