### PR TITLE
Iri parsing performance improvement

### DIFF
--- a/bench/src/main/resources/schema.json
+++ b/bench/src/main/resources/schema.json
@@ -1,0 +1,610 @@
+{
+  "@context": {
+    "nxv": "https://bluebrain.github.io/nexus/vocabulary/",
+    "distribution": {
+      "@id": "http://schema.org/distribution"
+    },
+    "id": "@id",
+    "type": "@type",
+    "links": {
+      "@id": "nxv:links"
+    },
+    "dcterms": "http://purl.org/dc/terms/",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "prov": "http://www.w3.org/ns/prov#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "schema": "http://schema.org/",
+    "sh": "http://www.w3.org/ns/shacl#",
+    "shsh": "http://www.w3.org/ns/shacl-shacl#",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "shext": "http://www.w3.org/ns/shacl/ext#",
+    "class": {
+      "@id": "sh:class",
+      "@type": "@id"
+    },
+    "rootClass": {
+      "@id": "shext:rootClass",
+      "@type": "@id"
+    },
+    "path": {
+      "@id": "sh:path",
+      "@type": "@id"
+    },
+    "qualifiedValueShape": {
+      "@id": "sh:qualifiedValueShape",
+      "@type": "@id"
+    },
+    "qualifiedValueShapesDisjoint": {
+      "@id": "sh:qualifiedValueShapesDisjoint",
+      "@type": "xsd:boolean"
+    },
+    "qualifiedMinCount": {
+      "@id": "sh:qualifiedMinCount",
+      "@type": "xsd:integer"
+    },
+    "qualifiedMaxCount": {
+      "@id": "sh:qualifiedMaxCount",
+      "@type": "xsd:integer"
+    },
+    "maxCount": {
+      "@id": "sh:maxCount",
+      "@type": "xsd:integer"
+    },
+    "minCount": {
+      "@id": "sh:minCount",
+      "@type": "xsd:integer"
+    },
+    "minInclusive": {
+      "@id": "sh:minInclusive"
+    },
+    "maxInclusive": {
+      "@id": "sh:maxInclusive"
+    },
+    "maxExclusive": {
+      "@id": "sh:maxExclusive"
+    },
+    "minExclusive": {
+      "@id": "sh:minExclusive"
+    },
+    "in": {
+      "@id": "sh:in",
+      "@container": "@list"
+    },
+    "imports": {
+      "@id": "owl:imports",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "datatype": {
+      "@id": "sh:datatype",
+      "@type": "@id"
+    },
+    "description": {
+      "@id": "sh:description"
+    },
+    "name": {
+      "@id": "sh:name"
+    },
+    "severity": {
+      "@id": "sh:severity"
+    },
+    "nodeKind": {
+      "@id": "sh:nodeKind",
+      "@type": "@id"
+    },
+    "BlankNode": {
+      "@id": "sh:BlankNode"
+    },
+    "BlankNodeOrIRI": {
+      "@id": "sh:BlankNodeOrIRI"
+    },
+    "BlankNodeOrLiteral": {
+      "@id": "sh:BlankNodeOrLiteral"
+    },
+    "IRI": {
+      "@id": "sh:IRI"
+    },
+    "IRIOrLiteral": {
+      "@id": "sh:IRIOrLiteral"
+    },
+    "Literal": {
+      "@id": "sh:Literal"
+    },
+    "prefix": {
+      "@id": "sh:prefix",
+      "@type": "xsd:string"
+    },
+    "declare": {
+      "@id": "sh:declare"
+    },
+    "namespace": {
+      "@id": "sh:namespace",
+      "@type": "xsd:anyURI"
+    },
+    "Violation": {
+      "@id": "sh:Violation"
+    },
+    "suggestedShapesGraph": {
+      "@id": "sh:suggestedShapesGraph",
+      "@type": "@id"
+    },
+    "shapesGraph": {
+      "@id": "sh:shapesGraph",
+      "@type": "@id"
+    },
+    "node": {
+      "@id": "sh:node",
+      "@type": "@id"
+    },
+    "property": {
+      "@id": "sh:property",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "targetClass": {
+      "@id": "sh:targetClass",
+      "@type": "@id"
+    },
+    "targetObjectsOf": {
+      "@id": "sh:targetObjectsOf",
+      "@type": "@id"
+    },
+    "targetSubjectsOf": {
+      "@id": "sh:targetSubjectsOf",
+      "@type": "@id"
+    },
+    "targetNode": {
+      "@id": "sh:targetNode",
+      "@type": "@id"
+    },
+    "target": {
+      "@id": "sh:target",
+      "@type": "@id"
+    },
+    "isDefinedBy": {
+      "@id": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+      "@type": "@id"
+    },
+    "shapes": {
+      "@reverse": "http://www.w3.org/2000/01/rdf-schema#isDefinedBy",
+      "@type": "@id",
+      "@container": "@set"
+    },
+    "Shape": {
+      "@id": "sh:Shape"
+    },
+    "NodeShape": {
+      "@id": "sh:NodeShape"
+    },
+    "PropertyShape": {
+      "@id": "sh:PropertyShape"
+    },
+    "or": {
+      "@id": "sh:or",
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "and": {
+      "@id": "sh:and",
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "xone": {
+      "@id": "sh:xone",
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "not": {
+      "@id": "sh:not",
+      "@type": "@id",
+      "@container": "@list"
+    },
+    "lessThan": {
+      "@id": "sh:lessThan",
+      "@type": "@id"
+    },
+    "hasValue": {
+      "@id": "sh:hasValue"
+    },
+    "resultMessage": {
+      "@id": "sh:message"
+    },
+    "deactivated": {
+      "@id": "sh:deactivated"
+    },
+    "pattern": {
+      "@id": "sh:pattern"
+    },
+    "label": {
+      "@id": "rdfs:label",
+      "@type": "xsd:string"
+    },
+    "comment": {
+      "@id": "rdfs:comment",
+      "@type": "xsd:string"
+    },
+    "editorialNote": {
+      "@id": "skos:editorialNote",
+      "@type": "xsd:string"
+    },
+    "seeAlso": {
+      "@id": "rdfs:seeAlso",
+      "@type": "@id"
+    },
+    "this": "https://bluebrain.github.io/nexus/schemas/resolver/shapes/"
+  },
+  "@id": "https://bluebrain.github.io/nexus/schemas/resolver",
+  "@type": "nxv:Schema",
+  "shapes": [
+    {
+      "@id": "this:ResolverShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "targetClass": [
+        "nxv:Resolver",
+        "nxv:CrossProject",
+        "nxv:InAccount"
+      ],
+      "or": [
+        {
+          "node": "this:CrossProjectResolverShape"
+        },
+        {
+          "node": "this:InAccountResolverShape"
+        }
+      ]
+    },
+    {
+      "@id": "this:CrossProjectResolverShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "sh:closed": true,
+      "property": [
+        {
+          "path": "rdf:type",
+          "name": "RDF types",
+          "description": "The rdf types.",
+          "nodeKind": "sh:IRI",
+          "sh:hasValue": {
+            "@id": "nxv:CrossProject"
+          },
+          "minCount": 2,
+          "maxCount": 2
+        },
+        {
+          "path": "nxv:priority",
+          "name": "Priority",
+          "description": "The priority of the resolver.",
+          "datatype": "xsd:integer",
+          "minInclusive": 0,
+          "maxInclusive": 1000,
+          "minCount": 1,
+          "maxCount": 1
+        },
+        {
+          "path": "nxv:resourceTypes",
+          "name": "Resource types",
+          "description": "The resource types that are to be applied for this resolver.",
+          "nodeKind": "sh:IRI",
+          "minCount": 0
+        },
+        {
+          "path": "nxv:projects",
+          "name": "Project UID",
+          "description": "The project UUID",
+          "datatype": "xsd:string",
+          "minCount": 1
+        },
+        {
+          "path": "nxv:identities",
+          "name": "UserRef identities",
+          "description": "The identities used to enforce security into this resolver.",
+          "sh:qualifiedValueShape": {
+            "class": "nxv:UserRef"
+          },
+          "qualifiedValueShapesDisjoint": true,
+          "seeAlso": "this:UserRefIdentityShape"
+        },
+        {
+          "path": "nxv:identities",
+          "name": "GroupRef identities",
+          "description": "The identities used to enforce security into this resolver.",
+          "sh:qualifiedValueShape": {
+            "class": "nxv:GroupRef"
+          },
+          "qualifiedValueShapesDisjoint": true,
+          "seeAlso": "this:GroupRefIdentityShape"
+        },
+        {
+          "path": "nxv:identities",
+          "name": "AuthenticatedRef identities",
+          "description": "The identities used to enforce security into this resolver.",
+          "sh:qualifiedValueShape": {
+            "class": "nxv:AuthenticatedRef"
+          },
+          "qualifiedValueShapesDisjoint": true,
+          "seeAlso": "this:AuthenticatedRefIdentityShape"
+        },
+        {
+          "path": "nxv:identities",
+          "name": "Anonymous identities",
+          "description": "The identities used to enforce security into this resolver.",
+          "sh:qualifiedValueShape": {
+            "class": "nxv:Anonymous"
+          },
+          "qualifiedValueShapesDisjoint": true,
+          "seeAlso": "this:AnonymousIdentityShape"
+        }
+      ]
+    },
+    {
+      "@id": "this:InAccountResolverShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "sh:closed": true,
+      "property": [
+        {
+          "path": "rdf:type",
+          "name": "RDF types",
+          "description": "The rdf types.",
+          "nodeKind": "sh:IRI",
+          "minCount": 2,
+          "maxCount": 2,
+          "sh:hasValue": {
+            "@id": "nxv:InAccount"
+          }
+        },
+        {
+          "path": "nxv:priority",
+          "name": "Priority",
+          "description": "The priority of the resolver.",
+          "datatype": "xsd:integer",
+          "minInclusive": 0,
+          "maxInclusive": 1000,
+          "minCount": 1,
+          "maxCount": 1
+        },
+        {
+          "path": "nxv:resourceTypes",
+          "name": "Resource types",
+          "description": "The resource types that are to be applied for this resolver.",
+          "nodeKind": "sh:IRI",
+          "minCount": 0
+        },
+        {
+          "path": "nxv:identities",
+          "name": "UserRef identities",
+          "description": "The identities used to enforce security into this resolver.",
+          "sh:qualifiedValueShape": {
+            "class": "nxv:UserRef"
+          },
+          "qualifiedValueShapesDisjoint": true,
+          "seeAlso": "this:UserRefIdentityShape"
+        },
+        {
+          "path": "nxv:identities",
+          "name": "GroupRef identities",
+          "description": "The identities used to enforce security into this resolver.",
+          "sh:qualifiedValueShape": {
+            "class": "nxv:GroupRef"
+          },
+          "qualifiedValueShapesDisjoint": true,
+          "seeAlso": "this:GroupRefIdentityShape"
+        },
+        {
+          "path": "nxv:identities",
+          "name": "AuthenticatedRef identities",
+          "description": "The identities used to enforce security into this resolver.",
+          "sh:qualifiedValueShape": {
+            "class": "nxv:AuthenticatedRef"
+          },
+          "qualifiedValueShapesDisjoint": true,
+          "seeAlso": "this:AuthenticatedRefIdentityShape"
+        },
+        {
+          "path": "nxv:identities",
+          "name": "Anonymous identities",
+          "description": "The identities used to enforce security into this resolver.",
+          "sh:qualifiedValueShape": {
+            "class": "nxv:Anonymous"
+          },
+          "qualifiedValueShapesDisjoint": true,
+          "seeAlso": "this:AnonymousIdentityShape"
+        }
+      ]
+    },
+    {
+      "@id": "this:InProjetResolverShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNodeOrIRI",
+      "sh:closed": true,
+      "property": [
+        {
+          "path": "rdf:type",
+          "name": "RDF types",
+          "description": "The rdf types.",
+          "nodeKind": "sh:IRI",
+          "minCount": 2,
+          "maxCount": 2,
+          "sh:hasValue": {
+            "@id": "nxv:InProject"
+          }
+        },
+        {
+          "path": "nxv:priority",
+          "name": "Priority",
+          "description": "The priority of the resolver.",
+          "datatype": "xsd:integer",
+          "minInclusive": 0,
+          "maxInclusive": 1000,
+          "minCount": 1,
+          "maxCount": 1
+        },
+        {
+          "path": "nxv:resourceTypes",
+          "name": "Resource types",
+          "description": "The resource types that are to be applied for this resolver.",
+          "nodeKind": "sh:IRI",
+          "minCount": 0
+        },
+        {
+          "path": "nxv:identities",
+          "name": "UserRef identities",
+          "description": "The identities used to enforce security into this resolver.",
+          "sh:qualifiedValueShape": {
+            "class": "nxv:UserRef"
+          },
+          "qualifiedValueShapesDisjoint": true,
+          "seeAlso": "this:UserRefIdentityShape"
+        },
+        {
+          "path": "nxv:identities",
+          "name": "GroupRef identities",
+          "description": "The identities used to enforce security into this resolver.",
+          "sh:qualifiedValueShape": {
+            "class": "nxv:GroupRef"
+          },
+          "qualifiedValueShapesDisjoint": true,
+          "seeAlso": "this:GroupRefIdentityShape"
+        },
+        {
+          "path": "nxv:identities",
+          "name": "AuthenticatedRef identities",
+          "description": "The identities used to enforce security into this resolver.",
+          "sh:qualifiedValueShape": {
+            "class": "nxv:AuthenticatedRef"
+          },
+          "qualifiedValueShapesDisjoint": true,
+          "seeAlso": "this:AuthenticatedRefIdentityShape"
+        },
+        {
+          "path": "nxv:identities",
+          "name": "Anonymous identities",
+          "description": "The identities used to enforce security into this resolver.",
+          "sh:qualifiedValueShape": {
+            "class": "nxv:Anonymous"
+          },
+          "qualifiedValueShapesDisjoint": true,
+          "seeAlso": "this:AnonymousIdentityShape"
+        }
+      ]
+    },
+    {
+      "@id": "this:UserRefIdentityShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNode",
+      "sh:closed": true,
+      "property": [
+        {
+          "path": "rdf:type",
+          "name": "RDF types",
+          "description": "The rdf types.",
+          "nodeKind": "sh:IRI",
+          "minCount": 1,
+          "maxCount": 1,
+          "sh:hasValue": {
+            "@id": "nxv:UserRef"
+          }
+        },
+        {
+          "path": "nxv:realm",
+          "name": "Realm",
+          "description": "The OIDC Provider realm.",
+          "datatype": "xsd:string",
+          "minCount": 1,
+          "maxCount": 1
+        },
+        {
+          "path": "nxv:sub",
+          "name": "Subject",
+          "description": "The OIDC Provider subject.",
+          "datatype": "xsd:string",
+          "minCount": 1,
+          "maxCount": 1
+        }
+      ]
+    },
+    {
+      "@id": "this:GroupRefIdentityShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNode",
+      "sh:closed": true,
+      "property": [
+        {
+          "path": "rdf:type",
+          "name": "RDF types",
+          "description": "The rdf types.",
+          "nodeKind": "sh:IRI",
+          "minCount": 1,
+          "maxCount": 1,
+          "sh:hasValue": {
+            "@id": "nxv:GroupRef"
+          }
+        },
+        {
+          "path": "nxv:realm",
+          "name": "Realm",
+          "description": "The OIDC Provider realm.",
+          "datatype": "xsd:string",
+          "minCount": 1,
+          "maxCount": 1
+        },
+        {
+          "path": "nxv:group",
+          "name": "Group",
+          "description": "The OIDC Provider group.",
+          "datatype": "xsd:string",
+          "minCount": 1,
+          "maxCount": 1
+        }
+      ]
+    },
+    {
+      "@id": "this:AuthenticatedRefIdentityShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNode",
+      "sh:closed": true,
+      "property": [
+        {
+          "path": "rdf:type",
+          "name": "RDF types",
+          "description": "The rdf types.",
+          "nodeKind": "sh:IRI",
+          "minCount": 1,
+          "maxCount": 1,
+          "sh:hasValue": {
+            "@id": "nxv:AuthenticatedRef"
+          }
+        },
+        {
+          "path": "nxv:realm",
+          "name": "Realm",
+          "description": "The OIDC Provider realm.",
+          "datatype": "xsd:string",
+          "minCount": 0,
+          "maxCount": 1
+        }
+      ]
+    },
+    {
+      "@id": "this:AnonymousIdentityShape",
+      "@type": "sh:NodeShape",
+      "nodeKind": "sh:BlankNode",
+      "sh:closed": true,
+      "property": [
+        {
+          "path": "rdf:type",
+          "name": "RDF types",
+          "description": "The rdf types.",
+          "nodeKind": "sh:IRI",
+          "minCount": 1,
+          "maxCount": 1,
+          "sh:hasValue": {
+            "@id": "nxv:Anonymous"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/bench/src/main/scala/ch/epfl/bluebrain/nexus/rdf/bench/Parsing.scala
+++ b/bench/src/main/scala/ch/epfl/bluebrain/nexus/rdf/bench/Parsing.scala
@@ -17,7 +17,10 @@ class Parsing {
 
   val iris = {
     import scala.collection.JavaConverters._
-    val json = parse(Source.fromFile(new File("/Users/roman/code/work/nexus/nexus-rdf/bench/src/main/resources/schema.json")).mkString).right.get
+    val json = parse(
+      Source
+        .fromFile(new File("/Users/roman/code/work/nexus/nexus-rdf/bench/src/main/resources/schema.json"))
+        .mkString).right.get
     val model = ModelFactory.createDefaultModel()
     RDFDataMgr.read(model, new ByteArrayInputStream(json.noSpaces.getBytes), Lang.JSONLD)
 
@@ -25,8 +28,8 @@ class Parsing {
       case (acc, stmt) =>
         val subj = if (stmt.getSubject.isURIResource) List(stmt.getSubject.getURI) else Nil
         val pred = if (stmt.getPredicate.isURIResource) List(stmt.getPredicate.getURI) else Nil
-        val obj = if (stmt.getObject.isURIResource) List(stmt.getObject.asResource().getURI) else Nil
-      subj ++ pred ++ obj ++ acc
+        val obj  = if (stmt.getObject.isURIResource) List(stmt.getObject.asResource().getURI) else Nil
+        subj ++ pred ++ obj ++ acc
     }
     println(s"IRIs: ${list.size}")
     list
@@ -48,7 +51,7 @@ class Parsing {
   def parseJenaIri(): Unit = {
     iris.foreach(i => {
       val iri = iriFactory.create(i)
-      val _ = iri.violations(true)
+      val _   = iri.violations(true)
     })
   }
 }

--- a/bench/src/main/scala/ch/epfl/bluebrain/nexus/rdf/bench/Parsing.scala
+++ b/bench/src/main/scala/ch/epfl/bluebrain/nexus/rdf/bench/Parsing.scala
@@ -1,0 +1,54 @@
+package ch.epfl.bluebrain.nexus.rdf.bench
+import java.io.{ByteArrayInputStream, File}
+
+import akka.http.scaladsl.model.Uri
+import ch.epfl.bluebrain.nexus.rdf.IriParser
+import io.circe.parser._
+import org.apache.jena.iri.IRIFactory
+import org.apache.jena.rdf.model.ModelFactory
+import org.apache.jena.riot.{Lang, RDFDataMgr}
+import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
+
+import scala.io.Source
+
+//noinspection TypeAnnotation
+@State(Scope.Thread)
+class Parsing {
+
+  val iris = {
+    import scala.collection.JavaConverters._
+    val json = parse(Source.fromFile(new File("/Users/roman/code/work/nexus/nexus-rdf/bench/src/main/resources/schema.json")).mkString).right.get
+    val model = ModelFactory.createDefaultModel()
+    RDFDataMgr.read(model, new ByteArrayInputStream(json.noSpaces.getBytes), Lang.JSONLD)
+
+    val list = model.listStatements().asScala.foldLeft[List[String]](Nil) {
+      case (acc, stmt) =>
+        val subj = if (stmt.getSubject.isURIResource) List(stmt.getSubject.getURI) else Nil
+        val pred = if (stmt.getPredicate.isURIResource) List(stmt.getPredicate.getURI) else Nil
+        val obj = if (stmt.getObject.isURIResource) List(stmt.getObject.asResource().getURI) else Nil
+      subj ++ pred ++ obj ++ acc
+    }
+    println(s"IRIs: ${list.size}")
+    list
+  }
+
+  val iriFactory = IRIFactory.iriImplementation()
+
+  @Benchmark
+  def parseIri(): Unit = {
+    iris.foreach(i => new IriParser(i).parseAbsolute)
+  }
+
+  @Benchmark
+  def parseAkkaUri(): Unit = {
+    iris.foreach(Uri.apply)
+  }
+
+  @Benchmark
+  def parseJenaIri(): Unit = {
+    iris.foreach(i => {
+      val iri = iriFactory.create(i)
+      val _ = iri.violations(true)
+    })
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -99,6 +99,16 @@ lazy val root = project
   )
   .aggregate(core, circe, jena, akka, nexus)
 
+lazy val bench = project
+  .in(file("bench"))
+  .enablePlugins(JmhPlugin)
+  .settings(noPublish)
+  .settings(
+    name       := "bench",
+    moduleName := "bench",
+  )
+  .dependsOn(core, jena, circe, akka, nexus)
+
 /* ********************************************************
  ******************** Grouped Settings ********************
  **********************************************************/

--- a/modules/core/src/main/scala/ch/epfl/bluebrain/nexus/rdf/Curie.scala
+++ b/modules/core/src/main/scala/ch/epfl/bluebrain/nexus/rdf/Curie.scala
@@ -1,12 +1,9 @@
 package ch.epfl.bluebrain.nexus.rdf
 
-import cats.syntax.either._
 import cats.syntax.show._
 import cats.{Eq, Show}
 import ch.epfl.bluebrain.nexus.rdf.Curie.Prefix
 import ch.epfl.bluebrain.nexus.rdf.Iri.RelativeIri
-import org.parboiled2.ErrorFormatter
-import org.parboiled2.Parser.DeliveryScheme.{Either => E}
 
 /**
   * A Compact URI as defined by W3C in ''CURIE Syntax 1.0''.
@@ -28,9 +25,7 @@ object Curie {
     * @return Right(Curie) if the string conforms to specification, Left(error) otherwise
     */
   final def apply(string: String): Either[String, Curie] =
-    new IriParser(string).`curie`
-      .run()
-      .leftMap(_.format(string, formatter))
+    new IriParser(string).parseCurie
 
   /**
     * The Compact URI prefix as defined by W3C in ''CURIE Syntax 1.0''.
@@ -49,9 +44,7 @@ object Curie {
       * @return Right(prefix) if the string conforms to specification, Left(error) otherwise
       */
     final def apply(string: String): Either[String, Prefix] =
-      new IriParser(string).`prefix`
-        .run()
-        .leftMap(_.format(string, formatter))
+      new IriParser(string).parseNcName
 
     final implicit val prefixShow: Show[Prefix] = Show.show(_.value)
     final implicit val prefixEq: Eq[Prefix]     = Eq.fromUniversalEquals
@@ -61,6 +54,4 @@ object Curie {
     Show.show { case Curie(prefix, reference) => prefix.show + ":" + reference.show }
 
   final implicit val curieEq: Eq[Curie] = Eq.fromUniversalEquals
-
-  private val formatter = new ErrorFormatter(showExpected = false, showTraces = false)
 }

--- a/modules/core/src/main/scala/ch/epfl/bluebrain/nexus/rdf/IriParser.scala
+++ b/modules/core/src/main/scala/ch/epfl/bluebrain/nexus/rdf/IriParser.scala
@@ -432,7 +432,7 @@ object IriParser {
             if (bytes == null) bytes = new Array[Byte]((numChars - i) / 3)
             var pos = 0
             while ({ ((i + 2) < numChars) && (c == '%') }) {
-              val v = Integer.parseInt(string, i + 1, i + 3, 16)
+              val v = Integer.parseInt(string.substring(i + 1, i + 3), 16)
               if (v < 0) throw new IllegalArgumentException("URLDecoder: Illegal hex characters in escape " + "(%) pattern - negative value")
               bytes({ pos += 1; pos - 1 }) = v.toByte
               i += 3

--- a/modules/core/src/main/scala/ch/epfl/bluebrain/nexus/rdf/IriParser.scala
+++ b/modules/core/src/main/scala/ch/epfl/bluebrain/nexus/rdf/IriParser.scala
@@ -1,287 +1,455 @@
 package ch.epfl.bluebrain.nexus.rdf
 
+import cats.syntax.either._
 import ch.epfl.bluebrain.nexus.rdf.Curie.Prefix
 import ch.epfl.bluebrain.nexus.rdf.Iri.Host.{IPv4Host, NamedHost}
+import ch.epfl.bluebrain.nexus.rdf.Iri.Path.{Segment, Slash}
 import ch.epfl.bluebrain.nexus.rdf.Iri._
-import ch.epfl.bluebrain.nexus.rdf.Iri.Path._
+import com.github.ghik.silencer.silent
 import org.parboiled2.CharPredicate._
-import org.parboiled2.CharUtils._
+import org.parboiled2.Parser.DeliveryScheme.{Either => E}
 import org.parboiled2._
+import java.lang.{StringBuilder => JStringBuilder}
+import java.nio.charset.Charset
 
 import scala.collection.immutable.{SortedMap, SortedSet}
 
-//noinspection TypeAnnotation
 // format: off
-@SuppressWarnings(Array("MethodNames"))
-class IriParser(val input: ParserInput) extends Parser {
+@SuppressWarnings(Array("MethodNames", "unused"))
+@silent
+private[rdf] class IriParser(val input: ParserInput)
+  (implicit formatter: ErrorFormatter = new ErrorFormatter(showExpected = false, showTraces = false))
+  extends Parser with StringBuilding {
 
-  def _scheme = rule {
-    capture(Alpha ~ zeroOrMore(AlphaNum ++ "+-.")) ~> ((str: String) => new Scheme(str.toLowerCase))
+  def parseScheme: Either[String, Scheme] =
+    rule(scheme ~ EOI).run()
+      .map(_ => _scheme)
+      .leftMap(_.format(input, formatter))
+
+  def parseIPv4: Either[String, IPv4Host] =
+    rule(IPv4address ~ EOI).run()
+      .map(_ => _host.asInstanceOf[IPv4Host])
+      .leftMap(_.format(input, formatter))
+
+  def parseNamed: Either[String, NamedHost] =
+    rule(`ireg-name` ~ EOI).run()
+      .map(_ => _host.asInstanceOf[NamedHost])
+      .leftMap(_.format(input, formatter))
+
+  def parsePort: Either[String, Port] =
+    rule(`port` ~ EOI).run()
+      .leftMap(_.format(input, formatter))
+      .flatMap(_ => Port(_port))
+
+  def parseUserInfo: Either[String, UserInfo] =
+    rule(`iuserinfo` ~ EOI).run()
+      .map(_ => _userInfo)
+      .leftMap(_.format(input, formatter))
+
+  def parsePathAbempty: Either[String, Path] =
+    rule(`ipath-abempty` ~ EOI).run()
+      .map(_ => _path)
+      .leftMap(_.format(input, formatter))
+
+  def parsePathSegment: Either[String, Path] =
+    rule(`isegment-nz` ~ EOI ~ push(getDecodedSB)).run()
+      .map(str => Segment(str, Path.Empty))
+      .leftMap(_.format(input, formatter))
+
+  def parseQuery: Either[String, Query] =
+    rule(`iquery` ~ EOI).run()
+      .map(_ => _query)
+      .leftMap(_.format(input, formatter))
+
+  def parseFragment: Either[String, Fragment] =
+    rule(`ifragment` ~ EOI).run()
+      .map(_ => _fragment)
+      .leftMap(_.format(input, formatter))
+
+  def parseUrl: Either[String, Url] =
+    rule(`url`).run()
+      .map(_ => Url(
+        scheme    = _scheme,
+        authority = Option(_authority),
+        path      = _path,
+        query     = Option(_query),
+        fragment  = Option(_fragment))
+      )
+      .leftMap(_.format(input, formatter))
+
+  def parseUrn: Either[String, Urn] =
+    rule(`urn`).run()
+      .map(_ => Urn(
+        nid      = _nid,
+        nss      = _path,
+        r        = Option(_r),
+        q        = Option(_query),
+        fragment = Option(_fragment))
+      )
+    .leftMap(_.format(input, formatter))
+
+  def parseAbsolute: Either[String, AbsoluteIri] =
+    rule(`urn` | `url`).run()
+      .map { _ =>
+        if (_nid != null) Urn(
+          nid      = _nid,
+          nss      = _path,
+          r        = Option(_r),
+          q        = Option(_query),
+          fragment = Option(_fragment))
+        else Url(
+          scheme    = _scheme,
+          authority = Option(_authority),
+          path      = _path,
+          query     = Option(_query),
+          fragment  = Option(_fragment))
+      }
+      .leftMap(_.format(input, formatter))
+
+  def parseRelative: Either[String, RelativeIri] =
+    rule(`irelative-ref` ~ EOI).run()
+      .map(_ => RelativeIri(
+        authority = Option(_authority),
+        path      = _path,
+        query     = Option(_query),
+        fragment  = Option(_fragment))
+      )
+      .leftMap(_.format(input, formatter))
+
+  def parseNid: Either[String, Nid] =
+    rule(`nid` ~ EOI).run()
+      .map(_ => _nid)
+      .leftMap(_.format(input, formatter))
+
+  def parseComponent: Either[String, Component] =
+    rule(`component` ~ EOI).run()
+      .leftMap(_.format(input, formatter))
+
+  def parseCurie: Either[String, Curie] =
+    rule(`curie`).run()
+      .map { _ =>
+        val prefix    = _ncName
+        val reference = RelativeIri(
+          authority = Option(_authority),
+          path      = _path,
+          query     = Option(_query),
+          fragment  = Option(_fragment))
+        Curie(prefix, reference)
+      }
+      .leftMap(_.format(input, formatter))
+
+  def parseNcName: Either[String, Prefix] =
+    rule(`nc-name` ~ EOI).run()
+      .map(_ => _ncName)
+      .leftMap(_.format(input, formatter))
+
+  private def appendSBAsLower(): Rule0 = rule { run(sb.append(CharUtils.toLowerCase(lastChar))) }
+  private def getDecodedSB: String = IriParser.decode(sb.toString, UTF8)
+
+  private[this] var _scheme: Scheme = _
+  private[this] var _host: Host = _
+  private[this] var _port: Int = 0
+  private[this] var _userInfo: UserInfo = _
+  private[this] var _authority: Authority = _
+  private[this] var _path: Path = Path.Empty
+  private[this] var _query: Query = _
+  private[this] var _fragment: Fragment = _
+
+  private[this] var _nid: Nid = _
+  private[this] var _r: Component = _
+
+  private[this] var _ncName: Prefix = _
+
+  private val schemeNonFirstPred = AlphaNum ++ "+-."
+  private def scheme: Rule0 = rule {
+    clearSB() ~ Alpha ~ appendSBAsLower() ~ zeroOrMore(schemeNonFirstPred ~ appendSBAsLower()) ~ run {
+      _scheme = new Scheme(sb.toString)
+    }
   }
 
-  def `scheme` = rule { _scheme ~ EOI }
+  private val Digit04 = CharPredicate('0' to '4')
+  private val Digit05 = CharPredicate('0' to '5')
 
-  val Digit04 = CharPredicate('0' to '4')
-  val Digit05 = CharPredicate('0' to '5')
-
-  def `dec-octet` = rule {
+  private def `dec-octet`: Rule1[Byte] = rule {
     capture(
       (ch('2') ~ ((Digit04 ~ Digit) | (ch('5') ~ Digit05)))
         | (ch('1') ~ Digit ~ Digit)
         | (Digit19 ~ Digit)
         | Digit
-    ) ~> ((str: String) => str.toInt.toByte)
+    ) ~> ((str: String) => java.lang.Integer.parseInt(str).toByte)
   }
 
-  def _ipv4Address = rule {
-    `dec-octet` ~ "." ~ `dec-octet` ~ "." ~ `dec-octet` ~ "." ~ `dec-octet` ~> (IPv4Host(_, _, _, _))
+  private def IPv4address: Rule0 = rule {
+    clearSB() ~ `dec-octet` ~ "." ~ `dec-octet` ~ "." ~ `dec-octet` ~ "." ~ `dec-octet` ~> ((a: Byte, b: Byte, c: Byte, d: Byte) => {
+      _host = IPv4Host(a, b, c, d)
+    })
   }
 
-  def `IPv4Address` = rule { _ipv4Address ~ EOI }
-
-  val ucscharRanges = Set(
+  private val `ucschar` = List(
     0xA0    to 0xD7FF,  0xF900  to 0xFDCF,  0xFDF0  to 0xFFEF,
     0x10000 to 0x1FFFD, 0x20000 to 0x2FFFD, 0x30000 to 0x3FFFD,
     0x40000 to 0x4FFFD, 0x50000 to 0x5FFFD, 0x60000 to 0x6FFFD,
     0x70000 to 0x7FFFD, 0x80000 to 0x8FFFD, 0x90000 to 0x9FFFD,
     0xA0000 to 0xAFFFD, 0xB0000 to 0xBFFFD, 0xC0000 to 0xCFFFD,
     0xD0000 to 0xDFFFD, 0xE1000 to 0xEFFFD
-  )
-  val iprivateRanges = Set(0xE000 to 0xF8FF, 0xF0000 to 0xFFFFD, 0x100000 to 0x10FFFD)
+  ).map(r => CharPredicate.from(c => r contains c.toInt)).reduce(_ ++ _)
 
-  def `sub-delims` = CharPredicate("!$&'()*+,;=")
-  def `ucschar` = CharPredicate.from(ch => ucscharRanges.exists(_.contains(ch.toInt)))
-  def `iunreserved` = AlphaNum ++ CharPredicate("-._~") ++ `ucschar`
-  def `iprivate`: CharPredicate = CharPredicate.from(ch => iprivateRanges.exists(_.contains(ch.toInt)))
+  private val `sub-delims` = CharPredicate("!$&'()*+,;=")
 
-  def `pct-encoded` = rule {
-    ch('%') ~ capture(HexDigit) ~ capture(HexDigit) ~> ((c1, c2) => (hexValue(c1.charAt(0)) * 16 + hexValue(c2.charAt(0))).toByte)
-  }
+  private val `iunreserved` = AlphaNum ++ CharPredicate("-._~") ++ `ucschar`
 
-  def _pctEncoded: Rule1[String] = rule {
-    oneOrMore(`pct-encoded`) ~> ((seq: Seq[Byte]) => new String(seq.toArray, "UTF-8"))
-  }
+  private val `iprivate` = List(
+    0xE000 to 0xF8FF, 0xF0000 to 0xFFFFD, 0x100000 to 0x10FFFD
+  ).map(r => CharPredicate.from(c => r contains c.toInt)).reduce(_ ++ _)
 
-  def _iRegName: Rule1[NamedHost] = rule {
-    zeroOrMore(_pctEncoded | capture(oneOrMore(`sub-delims` ++ `iunreserved`))) ~> ((seq: Seq[String]) => new NamedHost(seq.mkString.toLowerCase))
-  }
-
-  def `ireg-name` = rule { _iRegName ~ EOI }
-
-  def _portLiteral = rule {
-    capture((Digit19 ~ (1 to 4).times(Digit).?) | ch('0')) ~> ((str: String) => Integer.parseInt(str))
-  }
-
-  def _port = rule {
-    _portLiteral ~> (up => test(Port(up).isRight) ~ push(new Port(up)))
-  }
-
-  def `port` = rule { _port ~ EOI }
-
-  def _userInfo = rule {
-    oneOrMore(_pctEncoded | capture(oneOrMore(`sub-delims` ++ `iunreserved` ++ ':'))) ~> ((seq: Seq[String]) => new UserInfo(seq.mkString))
-  }
-
-  def `iuserinfo` = rule { _userInfo ~ EOI }
-
-  private val pathF = (p: Path, e: String)  => (p, e) match {
-    case (Segment(_, Slash(acc)), "..")     => acc
-    case (Slash(acc), "..")                 => acc
-    case (acc, "..")                        => acc
-    case (acc, ".")                         => acc
-    case (acc, el) if el.length == 0        => Slash(acc)
-    case (acc, el)                          => Segment(el, Slash(acc))
-  }
-
-  def _pathAbEmpty: Rule1[Path] = rule {
-    zeroOrMore(ch('/') ~ `isegment`) ~> ((seq: Seq[String]) => seq.foldLeft[Path](Path.Empty)(pathF))
-  }
-
-  def `ipath-abempty`: Rule1[Path] = rule { _pathAbEmpty ~ EOI }
-
-  def _pathRootless: Rule1[Path] = rule {
-    `isegment-nz` ~ zeroOrMore(ch('/') ~ `isegment`) ~> ((str: String, seq: Seq[String]) => seq.foldLeft[Path](Segment(str, Path.Empty)) {
-      case (acc, el) if el.length == 0 => Slash(acc)
-      case (acc, el)                   => Segment(el, Slash(acc))
-    })
-  }
-
-  def relativeWithAuthority: Rule1[(Option[Authority], Path)] = rule {
-    '/' ~ '/' ~ _authority ~ _pathAbEmpty ~> ((a: Authority, p: Path) => Some(a) -> p)
-  }
-
-  def relativeIpathAbsolute: Rule1[(Option[Authority], Path)] = rule {
-    _pathAbsolute ~> ((p: Path) => None -> p)
-  }
-
-  def relativeIpathNoScheme: Rule1[(Option[Authority], Path)] = rule {
-    `ipath-noscheme` ~> ((p: Path) => None -> p)
-  }
-
-  def `irelative-part`: Rule1[(Option[Authority], Path)] = rule {
-    optional(relativeWithAuthority | relativeIpathAbsolute | relativeIpathNoScheme) ~> ((opt: Option[(Option[Authority], Path)]) => opt.getOrElse((None, Path.Empty)))
-  }
-
-  def _irelativeRef: Rule1[RelativeIri] = rule {
-    `irelative-part` ~ optional(ch('?') ~ _query) ~ optional(ch('#') ~ _fragment) ~> {
-      (t: (Option[Authority], Path), q: Option[Query], f: Option[Fragment]) =>
-        val (auth, path) = t
-        test(path.nonEmpty || auth.isDefined || q.isDefined || f.isDefined) ~ push(RelativeIri(auth, path, q, f))
+  private def `pct-encoded`: Rule0 = rule {
+    '%' ~ HexDigit ~ HexDigit ~ run {
+      sb.append('%').append(charAt(-2)).append(lastChar)
     }
   }
 
-  def `irelative-ref`: Rule1[RelativeIri] = rule { _irelativeRef ~ EOI }
-
-  private def _pathAbsoluteStart(optString: Option[String]): Path = optString.map(Segment(_, Slash(Path.Empty))).getOrElse(Slash(Path.Empty))
-
-  def _pathAbsolute: Rule1[Path] = rule {
-    (ch('/') ~ optional(`isegment-nz`) ~ optional(zeroOrMore(ch('/') ~ `isegment`))) ~> ((str: Option[String], seq: Option[Seq[String]]) => seq.getOrElse(Seq.empty).foldLeft[Path](_pathAbsoluteStart(str))(pathF))
+  private val pathSegmentCharPred = `iunreserved` ++ `sub-delims` ++ ':' ++ '@'
+  private def `ipchar`: Rule0 = rule {
+    pathSegmentCharPred ~ appendSB() | `pct-encoded`
   }
 
-  def `ipath-noscheme` = rule {
-    `isegment-nz-nc` ~ zeroOrMore(ch('/') ~ `isegment`) ~> ((str: String, seq: Seq[String]) => seq.foldLeft[Path](Segment(str, Path.Empty)) {
-      case (Segment(el, Slash(acc)), "..") if el != ".."  => acc
-      case (Segment(el, acc), "..") if el != ".."         => acc
-      case (Slash(acc), "..")                             => acc
-      case (acc, ".")                                     => acc
-      case (acc, el) if el.length == 0                    => Slash(acc)
-      case (acc, el)                                      => Segment(el, Slash(acc))
-    })
-  }
-
-  def `isegment`: Rule1[String] = rule {
-    zeroOrMore(_pctEncoded | capture(oneOrMore(`sub-delims` ++ `iunreserved` ++ ':' ++ '@'))) ~> ((seq: Seq[String]) => seq.mkString)
-  }
-
-  def `isegment-nz`: Rule1[String] = rule {
-    oneOrMore(_pctEncoded | capture(oneOrMore(`sub-delims` ++ `iunreserved` ++ ':' ++ '@'))) ~> ((seq: Seq[String]) => seq.mkString)
-  }
-
-  def segment: Rule1[String] = rule { `isegment-nz` ~ EOI }
-
-  def `isegment-nz-nc`: Rule1[String] = rule {
-    oneOrMore(_pctEncoded | capture(oneOrMore(`sub-delims` ++ `iunreserved` ++ '@'))) ~> ((seq: Seq[String]) => seq.mkString)
-  }
-
-  private val queryFold = (seq: Seq[(String, String)]) => {
-    val map = seq.groupBy(_._1).mapValues(e => SortedSet(e.map(_._2): _*))
-    Query(SortedMap(map.toList: _*))
-  }
-
-  def _query: Rule1[Query] = rule {
-    zeroOrMore(_queryElement).separatedBy('&') ~> queryFold
-  }
-
-  def _queryElement: Rule1[(String, String)] = rule {
-    _queryElementPart ~ optional(ch('=') ~ _queryElementPart) ~> ((str: String, strOpt: Option[String]) => (str, strOpt.getOrElse("")))
-  }
-
-  def _queryElementPart: Rule1[String] = rule {
-    oneOrMore(_pctEncoded | capture(oneOrMore(!"?+" ~ (`sub-delims` ++ `iunreserved` ++ `iprivate` ++ CharPredicate(":@/?") -- CharPredicate("=&"))))) ~> ((seq: Seq[String]) => seq.mkString)
-  }
-
-  def `iquery` = rule { _query ~ EOI }
-
-  def _fragment: Rule1[Fragment] = rule {
-    zeroOrMore(_pctEncoded | capture(oneOrMore(`sub-delims` ++ `iunreserved` ++ CharPredicate(":@/?")))) ~> ((seq: Seq[String]) => new Fragment(seq.mkString))
-  }
-
-  def `ifragment` = rule { _fragment ~ EOI }
-
-  def _host: Rule1[Host] = rule {
-    _ipv4Address | _iRegName
-  }
-
-  def _authority: Rule1[Authority] = rule {
-    optional(_userInfo ~ ch('@')) ~ _host ~ optional(ch(':') ~ _port) ~> ((ui, h, p) => Authority(ui, h, p))
-  }
-
-  def authorityAndPath: Rule1[(Option[Authority], Path)] = rule {
-    "//" ~ _authority ~ optional(_pathAbEmpty)  ~> ((a: Authority, p: Option[Path]) => Some(a) -> p.getOrElse(Path.Empty))
-  }
-
-  def otherPaths: Rule1[(Option[Authority], Path)] = rule {
-    (_pathAbsolute | _pathRootless) ~> ((p: Path) => None -> p)
-  }
-
-  def `hier-part`: Rule1[(Option[Authority], Path)] = rule { authorityAndPath | otherPaths }
-
-  def _url: Rule1[Url] = rule {
-    _scheme ~ ch(':') ~ `hier-part` ~ optional(ch('?') ~ _query) ~ optional(ch('#') ~ _fragment) ~> {
-      (s: Scheme, ap: (Option[Authority],Path), q: Option[Query], f: Option[Fragment]) =>
-        val (a, p) = ap
-        Url(s, a, p, q, f)
+  private def `ireg-name`: Rule0 = rule {
+    clearSB() ~ oneOrMore((`iunreserved` ++ `sub-delims`) ~ appendSBAsLower() | `pct-encoded`) ~ run {
+      _host = new NamedHost(getDecodedSB.toLowerCase)
     }
   }
 
-  def url: Rule1[Url] = rule { _url ~ EOI }
-
-  val ldh = AlphaNum ++ '-'
-
-  def _nid: Rule1[Nid] = rule {
-    capture(AlphaNum ~ (1 to 31).times(ldh)) ~> ((chars: String) => test(lastChar.isLetterOrDigit) ~ push(new Nid(chars.toLowerCase)))
+  private def `port`: Rule0 = rule {
+    Digit19 ~ run { _port = lastChar - '0' } ~ optional(
+      Digit ~ run { _port = 10 * _port + (lastChar - '0') } ~ optional(
+        Digit ~ run { _port = 10 * _port + (lastChar - '0') } ~ optional(
+          Digit ~ run { _port = 10 * _port + (lastChar - '0') } ~ optional(
+            Digit ~ run { _port = 10 * _port + (lastChar - '0') } )))) | '0'
   }
 
-  def `nid`: Rule1[Nid] = rule { _nid ~ EOI }
+  private def `ihost`: Rule0 = rule { IPv4address | `ireg-name` }
 
-  def _nss: Rule1[Path] = rule { _pathRootless }
-
-  def `nss`: Rule1[Path] = rule { _nss ~ EOI }
-
-  def _component: Rule1[Component] = rule {
-    oneOrMore(_pctEncoded | capture(oneOrMore(`sub-delims` ++ `iunreserved` ++ ":@/")) | capture('?' ~ &(!(ch('+') | '=')))) ~> ((seq: Seq[String]) => new Component(seq.mkString))
+  private def `iuserinfo`: Rule0 = rule {
+    clearSB() ~ oneOrMore((`iunreserved` ++ `sub-delims` ++ ':') ~ appendSB() | `pct-encoded`) ~ run {
+      _userInfo = new UserInfo(getDecodedSB)
+    }
   }
 
-  def `component`: Rule1[Component] = rule { _component ~ EOI }
-
-  def _rFollowedByOptQ: Rule1[(Option[Component], Option[Query])] = rule {
-    "?+" ~ _component ~ optional("?=" ~ _queryNonEmpty) ~> ((c: Component, q: Option[Query]) => Some(c) -> q)
+  private def `iauthority`: Rule0 = rule {
+    clearSB() ~ optional(`iuserinfo` ~ '@' | run { _userInfo = null }) ~ `ihost` ~ optional(':' ~ port) ~ run {
+      _authority = Authority(Option(_userInfo), _host, if (_port == 0) None else Some(new Port(_port)))
+    }
   }
 
-  def _queryNonEmpty: Rule1[Query] = rule {
-    oneOrMore(_queryElement).separatedBy('&') ~> queryFold
+  private def `ipath-abempty`: Rule0 = {
+    def setPath(value: String): Unit = {
+      val res = (_path, value) match {
+        case (Segment(_, Slash(acc)), "..") => acc
+        case (Slash(acc), "..")             => acc
+        case (acc, "..")                    => acc
+        case (acc, ".")                     => acc
+        case (acc, el) if el.length == 0    => Slash(acc)
+        case (acc, el)                      => Segment(el, Slash(acc))
+      }
+      _path = res
+    }
+
+    rule {
+      zeroOrMore(clearSB() ~ '/' ~ `isegment` ~ run { setPath(getDecodedSB) })
+    }
   }
 
-  def _qFollowedByOptR: Rule1[(Option[Component], Option[Query])] = rule {
-    "?=" ~ _queryNonEmpty ~ optional("?+" ~ _component) ~> ((q: Query, r: Option[Component]) => r -> Some(q))
+  private def `ipath-absolute`: Rule0 = rule {
+    clearSB() ~ '/' ~ optional(`isegment` ~ run {
+      _path = if (sb.length() == 0) Slash(Path.Empty) else Segment(getDecodedSB, Slash(Path.Empty))
+    } ~ `ipath-abempty`)
   }
 
-  def _rqComponents: Rule1[(Option[Component], Option[Query])] = rule {
-    (_rFollowedByOptQ | _qFollowedByOptR).? ~> ((res: Option[(Option[Component], Option[Query])]) => res match {
-      case Some(v) => v
-      case None    => (None, None)
-    })
+  private def `ipath-noscheme`: Rule0 = {
+    def setPath(value: String): Unit = {
+      val res = (_path, value) match {
+        case (Segment(el, Slash(acc)), "..") if el != ".." => acc
+        case (Segment(el, acc), "..") if el != ".."        => acc
+        case (Slash(acc), "..")                            => acc
+        case (acc, ".")                                    => acc
+        case (acc, el) if el.length == 0                   => Slash(acc)
+        case (acc, el)                                     => Segment(el, Slash(acc))
+      }
+      _path = res
+    }
+
+    rule {
+      clearSB() ~ `isegment-nz-nc` ~ run {
+        _path = Segment(getDecodedSB, Path.Empty)
+      } ~ zeroOrMore(clearSB() ~ '/' ~ `isegment` ~ run { setPath(getDecodedSB) })
+    }
   }
 
-  def _urn: Rule1[Urn] = rule {
-    "urn:" ~ _nid ~ ":" ~ _nss ~ _rqComponents ~ optional('#' ~ _fragment) ~> ((nid: Nid, nss: Path, rq: (Option[Component], Option[Query]), f: Option[Fragment]) => Urn(nid, nss, rq._1, rq._2, f))
+  private def `ipath-rootless`: Rule0 = rule {
+    clearSB() ~ `isegment-nz` ~ run {
+      _path = Segment(getDecodedSB, Path.Empty)
+    } ~ `ipath-abempty`
   }
 
-  def urn: Rule1[Urn] = rule { _urn ~ EOI }
+  private def `ipath-empty`: Rule0 = rule {
+    clearSB() ~ MATCH ~ run {
+      _path = Path.Empty
+    }
+  }
 
-  private val nameStartUtfRanges = Set(
-    0xC0 to 0xD6,     0xD8 to 0xF6,     0xF8 to 0x2FF,
-    0x370 to 0x37D,   0x37F to 0x1FFF,  0x200C to 0x200D,
-    0x2070 to 0x218F, 0x2C00 to 0x2FEF, 0x300 to 0xD7FF,
+  private def `isegment`: Rule0 = rule { zeroOrMore(`ipchar`) }
+  private def `isegment-nz`: Rule0 = rule { oneOrMore(`ipchar`) }
+  private def `isegment-nz-nc`: Rule0 = rule { oneOrMore(!':' ~ `ipchar`) }
+
+  private val queryPartPred = `sub-delims` ++ `iunreserved` ++ `iprivate` ++ CharPredicate(":@/?") -- CharPredicate("=&")
+  private def `iquery`: Rule0 = {
+    def part: Rule1[String] = rule {
+      clearSB() ~ oneOrMore(!"?+" ~ ('+' ~ appendSB(' ') | queryPartPred ~ appendSB() | `pct-encoded`)) ~ push(getDecodedSB)
+    }
+
+    /*_*/
+    def entry: Rule1[(String, String)] = rule {
+      part ~ optional('=' ~ part) ~> ((key: String, value: Option[String]) => (key, value.getOrElse("")))
+    }
+    /*_*/
+
+    def setQuery(seq: Seq[(String, String)]): Unit = {
+      val map = seq.groupBy(_._1).mapValues(e => SortedSet(e.map(_._2): _*))
+      _query = Query(SortedMap(map.toList: _*))
+    }
+
+    /*_*/
+    rule {
+      zeroOrMore(entry).separatedBy('&') ~> ((seq: Seq[(String, String)]) => setQuery(seq))
+    }
+    /*_*/
+  }
+
+  private def `ifragment`: Rule0 = rule {
+    clearSB() ~ zeroOrMore(`ipchar` | (CharPredicate("/?") ~ appendSB())) ~ run {
+      _fragment = new Fragment(getDecodedSB)
+    }
+  }
+
+  private def `ihier-part`: Rule0 = rule {
+    ("//" ~ `iauthority` ~ `ipath-abempty`) | (run { _authority = null } ~ (`ipath-absolute` | `ipath-rootless` | `ipath-empty`))
+  }
+
+  private def `url`: Rule0 = rule {
+    scheme ~ ':' ~ `ihier-part` ~ optional('?' ~ `iquery`) ~ optional('#' ~ `ifragment`) ~ EOI
+  }
+
+  private def `irelative-part`: Rule0 = rule {
+    ("//" ~ `iauthority` ~ `ipath-abempty`) | `ipath-absolute` | `ipath-noscheme` | `ipath-empty`
+  }
+
+  private def `irelative-ref`: Rule0 = rule {
+    `irelative-part` ~ optional('?' ~ `iquery`) ~ optional('#' ~ `ifragment`) ~ test {
+      _path.nonEmpty || _authority != null || _query != null || _fragment != null
+    }
+  }
+
+  private val ldh = AlphaNum ++ '-'
+  private def `nid`: Rule0 = rule {
+    clearSB() ~ AlphaNum ~ appendSBAsLower() ~ (1 to 31).times(ldh ~ appendSBAsLower()) ~ test(AlphaNum(lastChar)) ~ run {
+      _nid = new Nid(sb.toString)
+    }
+  }
+
+  private def `nss`: Rule0 = rule {
+    `ipath-rootless`
+  }
+
+  private val componentPred = `sub-delims` ++ `iunreserved` ++ ":@/?"
+  private def `component`: Rule1[Component] = rule {
+    clearSB() ~ oneOrMore(!"?+" ~ !"?=" ~ componentPred ~ appendSB() | `pct-encoded`) ~ push(new Component(getDecodedSB))
+  }
+
+  private def `rq-components`: Rule0 = {
+    def `r-component`: Rule0 = rule {
+      "?+" ~ test(_r == null) ~ `component` ~> ((c: Component) => _r = c)
+    }
+
+    def `q-component`: Rule0 = rule {
+      "?=" ~ `iquery` ~ test(sb.length() > 0)
+    }
+
+    rule {
+      // r component can only be matched once per parser, this allows components to be commutative
+      optional(`r-component`) ~ optional(`q-component`) ~ optional(`r-component`)
+    }
+  }
+
+  private def `urn`: Rule0 = rule {
+    "urn:" ~ `nid` ~ ':' ~ `nss` ~ `rq-components` ~ optional('#' ~ `ifragment`) ~ EOI
+  }
+
+  private val `nc-name-start` = Alpha ++ '_' ++ List(
+    0xC0   to 0xD6,   0xD8   to 0xF6,   0xF8    to 0x2FF,
+    0x370  to 0x37D,  0x37F  to 0x1FFF, 0x200C  to 0x200D,
+    0x2070 to 0x218F, 0x2C00 to 0x2FEF, 0x300   to 0xD7FF,
     0xF900 to 0xFDCF, 0xFDF0 to 0xFFFD, 0x10000 to 0xEFFFF
-  )
-  private val nameStartUtf = CharPredicate.from(ch => nameStartUtfRanges.exists(_.contains(ch.toInt)))
+  ).map(r => CharPredicate.from(c => r contains c.toInt)).reduce(_ ++ _)
 
-  private def nameStart = rule { capture(LowerAlpha | UpperAlpha | ch('_') | nameStartUtf) }
-  private def name = rule {
-    nameStart | capture(ch('-') | ch('.') | Digit | ch('\u00B7') | CharPredicate('\u0300' to '\u036F') | CharPredicate('\u203F' to '\u2040'))
-  }
-  private def ncName = rule {
-    nameStart ~ zeroOrMore(name) ~> ((s: String, c: Seq[String]) => new Prefix(s"$s${c.mkString}"))
-  }
+  private val `nc-name-rest` = `nc-name-start` ++ Digit ++ CharPredicate("-.", "\u00B7", '\u0300' to '\u036F', '\u203F' to '\u2040')
 
-  def `prefix`: Rule1[Prefix] = rule { ncName ~ EOI }
-
-  def _curie: Rule1[Curie] = rule {
-    ncName ~ ch(':') ~ _irelativeRef ~> ((p: Prefix, r: RelativeIri) => new Curie(p, r))
+  private def `nc-name`: Rule0 = rule {
+    clearSB() ~ `nc-name-start` ~ appendSB() ~ zeroOrMore(`nc-name-rest` ~ appendSB()) ~ run {
+      _ncName = new Prefix(sb.toString)
+    }
   }
 
-  def `curie`: Rule1[Curie] = rule { _curie ~ EOI }
-
+  private def `curie`: Rule0 = rule {
+    `nc-name` ~ ':' ~ `irelative-ref` ~ EOI
+  }
 }
-// format: on
+
+object IriParser {
+
+  /**
+    * A direct port of the JDKs [[java.net.URLDecoder#decode(String, Charset)]] implementation that doesn't attempt to convert
+    * ''+'' into a space character '' ''. Decodes a percent encoded string using the specified charset.
+    *
+    * @param string  the string to decode
+    * @param charset the given charset
+    * @throws IllegalArgumentException if it encounters illegal characters
+    * @see [[java.net.URLDecoder#decode(String, Charset)]]
+    */
+  @SuppressWarnings(Array("NullAssignment", "NullParameter"))
+  private[rdf] def decode(string: String, charset: Charset): String = {
+    var needToChange = false
+    val numChars = string.length
+    val sb = new JStringBuilder(if (numChars > 500) numChars / 2 else numChars)
+    var i = 0
+
+    var c: Char = 0
+    var bytes: Array[Byte] = null
+    while (i < numChars) {
+      c = string.charAt(i)
+      c match {
+        case '%' =>
+          try {
+            if (bytes == null) bytes = new Array[Byte]((numChars - i) / 3)
+            var pos = 0
+            while ({ ((i + 2) < numChars) && (c == '%') }) {
+              val v = Integer.parseInt(string, i + 1, i + 3, 16)
+              if (v < 0) throw new IllegalArgumentException("URLDecoder: Illegal hex characters in escape " + "(%) pattern - negative value")
+              bytes({ pos += 1; pos - 1 }) = v.toByte
+              i += 3
+              if (i < numChars) c = string.charAt(i)
+            }
+            if ((i < numChars) && (c == '%')) throw new IllegalArgumentException("URLDecoder: Incomplete trailing escape (%) pattern")
+            sb.append(new String(bytes, 0, pos, charset))
+          } catch {
+            case e: NumberFormatException =>
+              throw new IllegalArgumentException("URLDecoder: Illegal hex characters in escape (%) pattern - " + e.getMessage)
+          }
+          needToChange = true
+        case _ =>
+          sb.append(c)
+          i += 1
+      }
+    }
+    if (needToChange) sb.toString else string
+  }
+}

--- a/modules/core/src/test/scala/ch/epfl/bluebrain/nexus/rdf/UrnSpec.scala
+++ b/modules/core/src/test/scala/ch/epfl/bluebrain/nexus/rdf/UrnSpec.scala
@@ -12,14 +12,13 @@ class UrnSpec extends WordSpecLike with Matchers with Inspectors with EitherValu
       // format: off
       val cases = List(
         "urn:uUid:6e8bc430-9c3a-11d9-9669-0800200c9a66"           -> "urn:uuid:6e8bc430-9c3a-11d9-9669-0800200c9a66",
-        "urn:example:a%C2%A3/b%C3%86c//:://?=a=b#"                 -> "urn:example:a£/bÆc//:://?=a=b#",
+        "urn:example:a%C2%A3/b%C3%86c//:://?=a=b#"                -> "urn:example:a£/bÆc//:://?=a=b#",
         "urn:lex:eu:council:directive:2010-03-09;2010-19-UE"      -> "urn:lex:eu:council:directive:2010-03-09;2010-19-UE",
         "urn:Example:weather?=op=map&lat=39.56&lon=-104.85#test"  -> "urn:example:weather?=lat=39.56&lon=-104.85&op=map#test",
         "urn:examp-lE:foo-bar-baz-qux?+CCResolve:cc=uk"           -> "urn:examp-le:foo-bar-baz-qux?+CCResolve:cc=uk",
         "urn:examp-lE:foo-bar-baz-qux?=a=b?+CCResolve:cc=uk"      -> "urn:examp-le:foo-bar-baz-qux?+CCResolve:cc=uk?=a=b",
         "urn:examp-lE:foo-bar-baz-qux?+CCResolve:cc=uk?=a=b"      -> "urn:examp-le:foo-bar-baz-qux?+CCResolve:cc=uk?=a=b",
         "urn:examp-lE:foo-bar-baz-qux?+CCResolve:cc=uk?=a=b#hash" -> "urn:examp-le:foo-bar-baz-qux?+CCResolve:cc=uk?=a=b#hash"
-
       )
       // format: on
       forAll(cases) {
@@ -29,7 +28,10 @@ class UrnSpec extends WordSpecLike with Matchers with Inspectors with EitherValu
     }
 
     "fail to parse" in {
-      val fail = List("urn:example:some/path/?=")
+      val fail = List(
+        "urn:example:some/path/?+",
+        "urn:example:some/path/?=",
+      )
       forAll(fail) { str =>
         Urn(str).left.value
       }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,3 +2,4 @@ resolvers += Resolver.bintrayRepo("bbp", "nexus-releases")
 
 addSbtPlugin("ch.epfl.bluebrain.nexus" % "sbt-nexus" % "0.10.9")
 addSbtPlugin("ch.epfl.scala"           % "sbt-bloop" % "1.0.0-M8")
+addSbtPlugin("pl.project13.scala"      % "sbt-jmh"   % "0.3.4")


### PR DESCRIPTION
The change uses a stateful parser implementation with mutable fields that is aproximately 1800 times faster than previous.

With this change the difference in performance compared to akka's uri parsing and jena's iri parsing is aproximately 5-5.5x (slower).
This is pretty acceptable considering the fact that the parser implementation automatically normalizes the iris and supports a wider character set.

Benchmarks - parsing 456 iris (higher is better):
Execution: `jmh:run -i 10 -wi 15 -f1 -t1`

Before:
```
[info] Benchmark                   Mode  Cnt     Score    Error  Units
[info] Parsing.parseAkkaUri       thrpt   10  1459,589 ± 57,703  ops/s
[info] Parsing.parseIri           thrpt   10     0,141 ±  0,001  ops/s
[info] Parsing.parseJenaIri       thrpt   10  1415,221 ± 18,911  ops/s
```

After:
```
[info] Benchmark              Mode  Cnt     Score    Error  Units
[info] Parsing.parseAkkaUri  thrpt   10  1383,506 ± 27,769  ops/s
[info] Parsing.parseIri      thrpt   10   263,601 ±  4,341  ops/s
[info] Parsing.parseJenaIri  thrpt   10  1450,212 ± 15,990  ops/s
```

The change also introduces a minimal parsing benchmark.

Fixes #8, #40.