### PR TITLE
Fixed decoding of percent-encoding string

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,11 +25,10 @@ scalafmt: {
  */
 
 // Dependency versions
-val akkaHttpVersion      = "10.1.8"
-val akkaStreamVersion    = "2.5.21"
+val akkaHttpVersion      = "10.1.9"
 val catsVersion          = "1.6.1"
 val circeVersion         = "0.11.1"
-val parboiledVersion     = "2.1.7"
+val parboiledVersion     = "2.1.8"
 val jenaVersion          = "3.12.0"
 val scalaGraphVersion    = "1.12.5"
 val scalaGraphDotVersion = "1.12.1"
@@ -37,7 +36,6 @@ val scalaTestVersion     = "3.0.8"
 
 // Dependency modules
 lazy val akkaHttpCore  = "com.typesafe.akka" %% "akka-http-core" % akkaHttpVersion
-lazy val akkaStream    = "com.typesafe.akka" %% "akka-stream"    % akkaStreamVersion
 lazy val catsCore      = "org.typelevel"     %% "cats-core"      % catsVersion
 lazy val circeCore     = "io.circe"          %% "circe-core"     % circeVersion
 lazy val circeParser   = "io.circe"          %% "circe-parser"   % circeVersion

--- a/src/main/scala/ch/epfl/bluebrain/nexus/rdf/IriParser.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/rdf/IriParser.scala
@@ -52,7 +52,7 @@ private[rdf] class IriParser(val input: ParserInput)
       .leftMap(_.format(input, formatter))
 
   def parsePathSegment: Either[String, Path] =
-    rule(`isegment-nz` ~ EOI ~ push(getDecodedSB)).run()
+    rule(`isegment-nz` ~ EOI ~ push(getDecodedSB(pCharDelims))).run()
       .map(str => Segment(str, Path.Empty))
       .leftMap(_.format(input, formatter))
 
@@ -144,7 +144,7 @@ private[rdf] class IriParser(val input: ParserInput)
       .leftMap(_.format(input, formatter))
 
   private def appendSBAsLower(): Rule0 = rule { run(sb.append(CharUtils.toLowerCase(lastChar))) }
-  private def getDecodedSB: String = IriParser.decode(sb.toString, UTF8)
+  private def getDecodedSB(exclude: Set[Char]): String = IriParser.decode(sb.toString, UTF8, exclude)
 
   private[this] var _scheme: Scheme = _
   private[this] var _host: Host = _
@@ -194,6 +194,11 @@ private[rdf] class IriParser(val input: ParserInput)
     0xD0000 to 0xDFFFD, 0xE1000 to 0xEFFFD
   ).map(r => CharPredicate.from(c => r contains c.toInt)).reduce(_ ++ _)
 
+  // Delimiters from https://tools.ietf.org/html/rfc3986#section-2.2
+  private val genDelims = Set(':', '/', '?', '#', '[', ']', '@')
+  // Delimiters computed from https://tools.ietf.org/html/rfc3986#section-3.3
+  private val pCharDelims = genDelims -- Set(':', '@')
+
   private val `sub-delims` = CharPredicate("!$&'()*+,;=")
 
   private val `iunreserved` = AlphaNum ++ CharPredicate("-._~") ++ `ucschar`
@@ -215,7 +220,7 @@ private[rdf] class IriParser(val input: ParserInput)
 
   private def `ireg-name`: Rule0 = rule {
     clearSB() ~ oneOrMore((`iunreserved` ++ `sub-delims`) ~ appendSBAsLower() | `pct-encoded`) ~ run {
-      _host = new NamedHost(getDecodedSB.toLowerCase)
+      _host = new NamedHost(getDecodedSB(genDelims).toLowerCase)
     }
   }
 
@@ -231,7 +236,7 @@ private[rdf] class IriParser(val input: ParserInput)
 
   private def `iuserinfo`: Rule0 = rule {
     clearSB() ~ oneOrMore((`iunreserved` ++ `sub-delims` ++ ':') ~ appendSB() | `pct-encoded`) ~ run {
-      _userInfo = new UserInfo(getDecodedSB)
+      _userInfo = new UserInfo(getDecodedSB(genDelims - ':'))
     }
   }
 
@@ -255,13 +260,13 @@ private[rdf] class IriParser(val input: ParserInput)
     }
 
     rule {
-      zeroOrMore(clearSB() ~ '/' ~ `isegment` ~ run { setPath(getDecodedSB) })
+      zeroOrMore(clearSB() ~ '/' ~ `isegment` ~ run { setPath(getDecodedSB(pCharDelims)) })
     }
   }
 
   private def `ipath-absolute`: Rule0 = rule {
     clearSB() ~ '/' ~ optional(`isegment` ~ run {
-      _path = if (sb.length() == 0) Slash(Path.Empty) else Segment(getDecodedSB, Slash(Path.Empty))
+      _path = if (sb.length() == 0) Slash(Path.Empty) else Segment(getDecodedSB(pCharDelims), Slash(Path.Empty))
     } ~ `ipath-abempty`)
   }
 
@@ -281,14 +286,14 @@ private[rdf] class IriParser(val input: ParserInput)
 
     rule {
       clearSB() ~ `isegment-nz-nc` ~ run {
-        _path = Segment(getDecodedSB, Path.Empty)
-      } ~ zeroOrMore(clearSB() ~ '/' ~ `isegment` ~ run { setPath(getDecodedSB) })
+        _path = Segment(getDecodedSB(genDelims - '@'), Path.Empty)
+      } ~ zeroOrMore(clearSB() ~ '/' ~ `isegment` ~ run { setPath(getDecodedSB(pCharDelims)) })
     }
   }
 
   private def `ipath-rootless`: Rule0 = rule {
     clearSB() ~ `isegment-nz` ~ run {
-      _path = Segment(getDecodedSB, Path.Empty)
+      _path = Segment(getDecodedSB(pCharDelims), Path.Empty)
     } ~ `ipath-abempty`
   }
 
@@ -305,7 +310,7 @@ private[rdf] class IriParser(val input: ParserInput)
   private val queryPartPred = `sub-delims` ++ `iunreserved` ++ `iprivate` ++ CharPredicate(":@/?") -- CharPredicate("=&")
   private def `iquery`: Rule0 = {
     def part: Rule1[String] = rule {
-      clearSB() ~ oneOrMore(!"?+" ~ ('+' ~ appendSB(' ') | queryPartPred ~ appendSB() | `pct-encoded`)) ~ push(getDecodedSB)
+      clearSB() ~ oneOrMore(!"?+" ~ ('+' ~ appendSB(' ') | queryPartPred ~ appendSB() | `pct-encoded`)) ~ push(getDecodedSB(pCharDelims - '/' - '?'))
     }
 
     /*_*/
@@ -328,7 +333,7 @@ private[rdf] class IriParser(val input: ParserInput)
 
   private def `ifragment`: Rule0 = rule {
     clearSB() ~ zeroOrMore(`ipchar` | (CharPredicate("/?") ~ appendSB())) ~ run {
-      _fragment = new Fragment(getDecodedSB)
+      _fragment = new Fragment(getDecodedSB(pCharDelims - '/' - '?'))
     }
   }
 
@@ -363,7 +368,7 @@ private[rdf] class IriParser(val input: ParserInput)
 
   private val componentPred = `sub-delims` ++ `iunreserved` ++ ":@/?"
   private def `component`: Rule1[Component] = rule {
-    clearSB() ~ oneOrMore(!"?+" ~ !"?=" ~ componentPred ~ appendSB() | `pct-encoded`) ~ push(new Component(getDecodedSB))
+    clearSB() ~ oneOrMore(!"?+" ~ !"?=" ~ componentPred ~ appendSB() | `pct-encoded`) ~ push(new Component(getDecodedSB(pCharDelims - '/' - '?')))
   }
 
   private def `rq-components`: Rule0 = {
@@ -408,16 +413,17 @@ private[rdf] class IriParser(val input: ParserInput)
 object IriParser {
 
   /**
-    * A direct port of the JDKs [[java.net.URLDecoder#decode(String, Charset)]] implementation that doesn't attempt to convert
-    * ''+'' into a space character '' ''. Decodes a percent encoded string using the specified charset.
+    * A direct port of the JDKs [[java.net.URLDecoder#decode(String, Charset)]] implementation that doesn't attempt to decode all characters.
+    * Decodes a percent encoded string using the specified charset.
     *
     * @param string  the string to decode
     * @param charset the given charset
+    * @param exclude the set of chars that are excluded from decoding
     * @throws IllegalArgumentException if it encounters illegal characters
     * @see [[java.net.URLDecoder#decode(String, Charset)]]
     */
   @SuppressWarnings(Array("NullAssignment", "NullParameter"))
-  private[rdf] def decode(string: String, charset: Charset): String = {
+  private[rdf] def decode(string: String, charset: Charset, exclude: Set[Char]): String = {
     var needToChange = false
     val numChars = string.length
     val sb = new JStringBuilder(if (numChars > 500) numChars / 2 else numChars)
@@ -425,22 +431,32 @@ object IriParser {
 
     var c: Char = 0
     var bytes: Array[Byte] = null
+    var hex: Array[String] = null
     while (i < numChars) {
       c = string.charAt(i)
       c match {
         case '%' =>
           try {
             if (bytes == null) bytes = new Array[Byte]((numChars - i) / 3)
+            if (hex == null) hex = new Array[String]((numChars - i) / 3)
             var pos = 0
             while ({ ((i + 2) < numChars) && (c == '%') }) {
-              val v = Integer.parseInt(string.substring(i + 1, i + 3), 16)
+              val encodedStr = string.substring(i + 1, i + 3)
+              val v = Integer.parseInt(encodedStr, 16)
               if (v < 0) throw new IllegalArgumentException("URLDecoder: Illegal hex characters in escape " + "(%) pattern - negative value")
-              bytes({ pos += 1; pos - 1 }) = v.toByte
+              val arrPos = pos
+              hex(arrPos) = encodedStr
+              bytes(arrPos) = v.toByte
+              pos += 1
               i += 3
               if (i < numChars) c = string.charAt(i)
             }
             if ((i < numChars) && (c == '%')) throw new IllegalArgumentException("URLDecoder: Incomplete trailing escape (%) pattern")
-            sb.append(new String(bytes, 0, pos, charset))
+            val decodedStr = new String(bytes, 0, pos, charset)
+            decodedStr.zipWithIndex.map {
+              case (char, idx) if exclude.contains(char) => sb.append(s"%${hex(idx)}")
+              case (char, _) => sb.append(char)
+            }
           } catch {
             case e: NumberFormatException =>
               throw new IllegalArgumentException("URLDecoder: Illegal hex characters in escape (%) pattern - " + e.getMessage)

--- a/src/test/scala/ch/epfl/bluebrain/nexus/rdf/IriSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/rdf/IriSpec.scala
@@ -25,9 +25,10 @@ class IriSpec extends WordSpecLike with Matchers with Inspectors with EitherValu
       "urn:lex:eu:council:directive:2010-03-09;2010-19-UE" -> "urn:lex:eu:council:directive:2010-03-09;2010-19-UE"
     )
     val casesUrl = List(
-      "hTtps://me:me@hOst:443/a/b?a&e=f&b=c#frag"   -> "https://me:me@host/a/b?a&b=c&e=f#frag",
-      "hTtps://me:me@hOst#frag"                     -> "https://me:me@host#frag",
-      "hTtp://hOst%C2%A3:80/a%C2%A3/b%C3%86c//:://" -> "http://host£/a£/bÆc//:://"
+      "hTtps://me:me@hOst:443/a/b?a&e=f&b=c#frag"                                                  -> "https://me:me@host/a/b?a&b=c&e=f#frag",
+      "hTtps://me:me@hOst#frag"                                                                    -> "https://me:me@host#frag",
+      "hTtp://hOst%C2%A3:80/a%C2%A3/b%C3%86c//:://"                                                -> "http://host£/a£/bÆc//:://",
+      "https://my%40user:my%3Apassword%24@myhost.com/a/path/http%3A%2F%2Fexample.com%2Fnxv%3Asome" -> "https://my%40user:my:password$@myhost.com/a/path/http:%2F%2Fexample.com%2Fnxv:some"
     )
 
     val casesUrlEncoded = List(


### PR DESCRIPTION
Fixes https://github.com/BlueBrain/nexus/issues/708

This fix reflects what it is described in the RFC3986 [Section 2.2](https://tools.ietf.org/html/rfc3986#section-2.2)  and [Section 2.3](https://tools.ietf.org/html/rfc3986#section-2.3). 

Basically says that reserved characters which are not specifically allowed in each rule, shouldn't be decoded when presented as percent-encoding since that would change the meaning of the Uri