### PR TITLE
Re-fixed pct-encoding (moved logic from decoding to encoding)

### DIFF
--- a/src/main/scala/ch/epfl/bluebrain/nexus/rdf/Iri.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/rdf/Iri.scala
@@ -500,7 +500,7 @@ object Iri {
     * @param value the underlying string representation
     */
   final case class UserInfo private[rdf] (value: String) {
-    private val charactersToIgnore = unreserved ++ `sub-delims` + ':'
+    private val allowedCharacters = unreserved ++ `sub-delims` + ':'
 
     /**
       * As per the specification the user info is case sensitive.  This method allows comparing two user info values
@@ -516,13 +516,13 @@ object Iri {
       * @return the string representation for the Userinfo segment compatible with the rfc3987
       *         (using percent-encoding only for delimiters)
       */
-    lazy val asString: String = value.pctEncodeInclude(`gen-delims` -- charactersToIgnore)
+    lazy val asString: String = value.pctEncodeInclude(`gen-delims` -- allowedCharacters)
 
     /**
       * @return the string representation using percent-encoding for the Userinfo segment
       *         when necessary according to rfc3986
       */
-    lazy val pctEncoded: String = value.pctEncodeIgnore(charactersToIgnore)
+    lazy val pctEncoded: String = value.pctEncodeIgnore(allowedCharacters)
   }
 
   object UserInfo {
@@ -751,11 +751,11 @@ object Iri {
       * @param value the underlying string representation
       */
     final case class NamedHost private[rdf] (value: String) extends Host {
-      private val charactersToIgnore          = unreserved ++ `sub-delims`
+      private val allowedCharacters           = unreserved ++ `sub-delims`
       override def isNamed: Boolean           = true
       override def asNamed: Option[NamedHost] = Some(this)
-      override lazy val pctEncoded            = value.pctEncodeIgnore(charactersToIgnore)
-      override lazy val asString              = value.pctEncodeInclude(`gen-delims` -- charactersToIgnore)
+      override lazy val pctEncoded            = value.pctEncodeIgnore(allowedCharacters)
+      override lazy val asString              = value.pctEncodeInclude(`gen-delims` -- allowedCharacters)
     }
 
     object NamedHost {
@@ -1108,8 +1108,8 @@ object Iri {
     * @param value a sorted multi map that represents all key -> value pairs
     */
   final case class Query private[rdf] (value: SortedMap[String, SortedSet[String]]) {
-    private val charactersToIgnore = pchar + '/' + '?'
-    private val charactersToEncode = `gen-delims` -- charactersToIgnore
+    private val allowedCharacters   = pchar + '/' + '?'
+    private val delimiterCharacters = `gen-delims` -- allowedCharacters
 
     /**
       * @return the string representation for the Query segment compatible with the rfc3987
@@ -1120,8 +1120,8 @@ object Iri {
         .map {
           case (k, s) =>
             s.map {
-                case v if v.isEmpty => k.pctEncodeInclude(charactersToEncode)
-                case v              => s"${k.pctEncodeInclude(charactersToEncode)}=${v.pctEncodeInclude(charactersToEncode)}"
+                case v if v.isEmpty => k.pctEncodeInclude(delimiterCharacters)
+                case v              => s"${k.pctEncodeInclude(delimiterCharacters)}=${v.pctEncodeInclude(delimiterCharacters)}"
               }
               .mkString("&")
         }
@@ -1136,8 +1136,8 @@ object Iri {
         .map {
           case (k, s) =>
             s.map {
-                case v if v.isEmpty => k.pctEncodeIgnore(charactersToIgnore)
-                case v              => s"${k.pctEncodeIgnore(charactersToIgnore)}=${v.pctEncodeIgnore(charactersToIgnore)}"
+                case v if v.isEmpty => k.pctEncodeIgnore(allowedCharacters)
+                case v              => s"${k.pctEncodeIgnore(allowedCharacters)}=${v.pctEncodeIgnore(allowedCharacters)}"
               }
               .mkString("&")
         }
@@ -1167,19 +1167,19 @@ object Iri {
     * @param value the string value of the fragment
     */
   final case class Fragment private[rdf] (value: String) {
-    private val charactersToIgnore = pchar + '/' + '?'
+    private val allowedCharacters = pchar + '/' + '?'
 
     /**
       * @return the string representation for the Path segment compatible with the rfc3987
       *         (using percent-encoding only for delimiters)
       */
-    lazy val asString: String = value.pctEncodeInclude(`gen-delims` -- charactersToIgnore)
+    lazy val asString: String = value.pctEncodeInclude(`gen-delims` -- allowedCharacters)
 
     /**
       * @return the string representation using percent-encoding for the Fragment segment
       *         when necessary according to rfc3986
       */
-    lazy val pctEncoded: String = value.pctEncodeIgnore(charactersToIgnore)
+    lazy val pctEncoded: String = value.pctEncodeIgnore(allowedCharacters)
 
   }
 
@@ -1204,19 +1204,19 @@ object Iri {
     * @param value the string value of the fragment
     */
   final case class Nid private[rdf] (value: String) {
-    private val charactersToIgnore = alpha ++ numeric + '/'
+    private val allowedCharacters = alpha ++ numeric + '/'
 
     /**
       * @return the string representation for the Nid segment compatible with the rfc3987
       *         (using percent-encoding only for delimiters)
       */
-    lazy val asString: String = value.pctEncodeInclude(`gen-delims` -- charactersToIgnore)
+    lazy val asString: String = value.pctEncodeInclude(`gen-delims` -- allowedCharacters)
 
     /**
       * @return the string representation using percent-encoding for the Nid segment
       *         when necessary according to rfc3986
       */
-    lazy val pctEncoded: String = value.pctEncodeIgnore(charactersToIgnore)
+    lazy val pctEncoded: String = value.pctEncodeIgnore(allowedCharacters)
   }
 
   object Nid {
@@ -1238,19 +1238,19 @@ object Iri {
     * Urn R or Q component as defined by RFC 8141.
     */
   final case class Component private[rdf] (value: String) {
-    private val charactersToIgnore = pchar + '/' + '?'
+    private val allowedCharacters = pchar + '/' + '?'
 
     /**
       * @return the string representation for the Component segment compatible with the rfc3987
       *         (using percent-encoding only for delimiters)
       */
-    lazy val asString: String = value.pctEncodeInclude(`gen-delims` -- charactersToIgnore)
+    lazy val asString: String = value.pctEncodeInclude(`gen-delims` -- allowedCharacters)
 
     /**
       * @return the string representation using percent-encoding for the Component segment
       *         when necessary according to rfc3986
       */
-    lazy val pctEncoded: String = value.pctEncodeIgnore(charactersToIgnore)
+    lazy val pctEncoded: String = value.pctEncodeIgnore(allowedCharacters)
   }
 
   object Component {

--- a/src/main/scala/ch/epfl/bluebrain/nexus/rdf/Iri.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/rdf/Iri.scala
@@ -7,7 +7,7 @@ import ch.epfl.bluebrain.nexus.rdf.Iri.Host.{IPv4Host, IPv6Host, NamedHost}
 import ch.epfl.bluebrain.nexus.rdf.Iri.Path._
 import ch.epfl.bluebrain.nexus.rdf.Iri._
 import ch.epfl.bluebrain.nexus.rdf.PctString._
-
+import ch.epfl.bluebrain.nexus.rdf.syntax._
 import scala.annotation.tailrec
 import scala.collection.immutable.SortedSet
 import scala.collection.{immutable, SeqView, SortedMap}
@@ -58,7 +58,8 @@ sealed abstract class Iri extends Product with Serializable {
   def asUrn: Option[Urn]
 
   /**
-    * @return the UTF-8 string representation of this Iri
+    * @return the string representation as a valid Iri
+    *         (using percent-encoding only for delimiters)
     */
   def asString: String
 
@@ -258,7 +259,7 @@ object Iri {
     final def apply(string: String): Either[String, RelativeIri] =
       new IriParser(string).parseRelative
 
-    final implicit val relativeIriShow: Show[RelativeIri] = Show.show(_.asUri)
+    final implicit val relativeIriShow: Show[RelativeIri] = Show.show(_.asString)
 
     final implicit val relativeIriEq: Eq[RelativeIri] = Eq.fromUniversalEquals
   }
@@ -407,7 +408,7 @@ object Iri {
     private[rdf] def unsafe(string: String): Url =
       apply(string).right.get
 
-    final implicit def urlShow: Show[Url] = Show.show(_.asUri)
+    final implicit def urlShow: Show[Url] = Show.show(_.asString)
 
     final implicit val urlEq: Eq[Url] = Eq.fromUniversalEquals
   }
@@ -464,7 +465,8 @@ object Iri {
   final case class Authority(userInfo: Option[UserInfo], host: Host, port: Option[Port]) {
 
     /**
-      * @return the UTF-8 representation
+      * @return the string representation for the Authority segment compatible with the rfc3987
+      *         (using percent-encoding only for delimiters)
       */
     lazy val asString: String = {
       val ui = userInfo.map(_.asString + "@").getOrElse("")
@@ -473,8 +475,8 @@ object Iri {
     }
 
     /**
-      * @return the string representation using percent-encoding for any character that
-      *         is not contained in the Set ''pchar''
+      * @return the string representation using percent-encoding for the Authority segment
+      *         when necessary according to rfc3986
       */
     lazy val pctEncoded: String = {
       {
@@ -498,6 +500,7 @@ object Iri {
     * @param value the underlying string representation
     */
   final case class UserInfo private[rdf] (value: String) {
+    private val charactersToIgnore = unreserved ++ `sub-delims` + ':'
 
     /**
       * As per the specification the user info is case sensitive.  This method allows comparing two user info values
@@ -510,17 +513,16 @@ object Iri {
       this.value equalsIgnoreCase that.value
 
     /**
-      * @return the UTF-8 representation
+      * @return the string representation for the Userinfo segment compatible with the rfc3987
+      *         (using percent-encoding only for delimiters)
       */
-    lazy val asString: String =
-      value
+    lazy val asString: String = value.pctEncodeInclude(`gen-delims` -- charactersToIgnore)
 
     /**
-      * @return the string representation using percent-encoding for any character that
-      *         is not contained in the Set ''pchar''
+      * @return the string representation using percent-encoding for the Userinfo segment
+      *         when necessary according to rfc3986
       */
-    lazy val pctEncoded: String =
-      pctEncode(value)
+    lazy val pctEncoded: String = value.pctEncodeIgnore(charactersToIgnore)
   }
 
   object UserInfo {
@@ -541,7 +543,7 @@ object Iri {
   /**
     * Host part of an Iri as defined in RFC 3987.
     */
-  sealed abstract class Host extends Product with Serializable with PctString {
+  sealed abstract class Host extends Product with Serializable {
 
     /**
       * @return true if the host is an IPv4 address, false otherwise
@@ -572,6 +574,20 @@ object Iri {
       * @return Some(this) if this is a NamedHost, None otherwise
       */
     def asNamed: Option[NamedHost] = None
+
+    def value: String
+
+    /**
+      * @return the string representation using percent-encoding for the Host segment
+      *         when necessary according to rfc3986
+      */
+    def pctEncoded: String
+
+    /**
+      * @return the string representation for the Host segment compatible with the rfc3987
+      *         (using percent-encoding only for delimiters)
+      */
+    def asString: String
   }
 
   object Host {
@@ -633,6 +649,8 @@ object Iri {
       override def isIPv4: Boolean          = true
       override def asIPv4: Option[IPv4Host] = Some(this)
       override lazy val value: String       = bytes.map(_ & 0xFF).mkString(".")
+      override lazy val pctEncoded          = value
+      override lazy val asString            = value
     }
 
     object IPv4Host {
@@ -689,6 +707,8 @@ object Iri {
     final case class IPv6Host private[rdf] (bytes: immutable.Seq[Byte]) extends Host {
       override def isIPv6: Boolean          = true
       override def asIPv6: Option[IPv6Host] = Some(this)
+      override lazy val pctEncoded          = value
+      override lazy val asString            = value
 
       override lazy val value: String =
         asString(bytes.view)
@@ -731,8 +751,11 @@ object Iri {
       * @param value the underlying string representation
       */
     final case class NamedHost private[rdf] (value: String) extends Host {
+      private val charactersToIgnore          = unreserved ++ `sub-delims`
       override def isNamed: Boolean           = true
       override def asNamed: Option[NamedHost] = Some(this)
+      override lazy val pctEncoded            = value.pctEncodeIgnore(charactersToIgnore)
+      override lazy val asString              = value.pctEncodeInclude(`gen-delims` -- charactersToIgnore)
     }
 
     object NamedHost {
@@ -870,13 +893,14 @@ object Iri {
     }
 
     /**
-      * @return the UTF-8 representation of this Path
+      * @return the string representation for the Path segment compatible with the rfc3987
+      *         (using percent-encoding only for delimiters)
       */
     def asString: String
 
     /**
-      * @return the string representation using percent-encoding for any character that
-      *         is not contained in the Set ''pchar''
+      * @return the string representation using percent-encoding for the Path segment
+      *         when necessary according to rfc3986
       */
     def pctEncoded: String
 
@@ -1046,7 +1070,6 @@ object Iri {
       */
     final case class Segment private[rdf] (segment: String, rest: Path) extends Path {
       type Head = String
-
       def isEmpty: Boolean                                   = false
       def head: String                                       = segment
       def tail(dropSlash: Boolean): Path                     = if (dropSlash && rest.endsWithSlash) rest.tail(dropSlash) else rest
@@ -1055,8 +1078,8 @@ object Iri {
       def asEmpty: Option[Empty]                             = None
       def asSlash: Option[Slash]                             = None
       def asSegment: Option[Segment]                         = Some(this)
-      def asString: String                                   = rest.asString + segment
-      def pctEncoded: String                                 = rest.pctEncoded + pctEncode(segment)
+      def asString: String                                   = rest.asString + segment.pctEncodeInclude(`gen-delims` -- pchar)
+      def pctEncoded: String                                 = rest.pctEncoded + segment.pctEncodeIgnore(pchar)
       def startWithSlash: Boolean                            = rest.startWithSlash
       def prepend(other: Path, allowSlashDup: Boolean): Path = rest.prepend(other, allowSlashDup) + segment
       def +(s: String): Path                                 = if (segment.isEmpty) this else Segment(segment + s, rest)
@@ -1085,33 +1108,36 @@ object Iri {
     * @param value a sorted multi map that represents all key -> value pairs
     */
   final case class Query private[rdf] (value: SortedMap[String, SortedSet[String]]) {
+    private val charactersToIgnore = pchar + '/' + '?'
+    private val charactersToEncode = `gen-delims` -- charactersToIgnore
 
     /**
-      * @return the UTF-8 representation of this Query
+      * @return the string representation for the Query segment compatible with the rfc3987
+      *         (using percent-encoding only for delimiters)
       */
-    def asString: String =
+    lazy val asString: String =
       value
         .map {
           case (k, s) =>
             s.map {
-                case v if v.isEmpty => k
-                case v              => s"$k=$v"
+                case v if v.isEmpty => k.pctEncodeInclude(charactersToEncode)
+                case v              => s"${k.pctEncodeInclude(charactersToEncode)}=${v.pctEncodeInclude(charactersToEncode)}"
               }
               .mkString("&")
         }
         .mkString("&")
 
     /**
-      * @return the string representation using percent-encoding for any character that
-      *         is not contained in the Set ''pchar''
+      * @return the string representation using percent-encoding for the Query segment
+      *         when necessary according to rfc3986
       */
-    def pctEncoded: String =
+    lazy val pctEncoded: String =
       value
         .map {
           case (k, s) =>
             s.map {
-                case v if v.isEmpty => pctEncode(k)
-                case v              => s"${pctEncode(k)}=${pctEncode(v)}"
+                case v if v.isEmpty => k.pctEncodeIgnore(charactersToIgnore)
+                case v              => s"${k.pctEncodeIgnore(charactersToIgnore)}=${v.pctEncodeIgnore(charactersToIgnore)}"
               }
               .mkString("&")
         }
@@ -1140,7 +1166,22 @@ object Iri {
     *
     * @param value the string value of the fragment
     */
-  final case class Fragment private[rdf] (value: String) extends PctString
+  final case class Fragment private[rdf] (value: String) {
+    private val charactersToIgnore = pchar + '/' + '?'
+
+    /**
+      * @return the string representation for the Path segment compatible with the rfc3987
+      *         (using percent-encoding only for delimiters)
+      */
+    lazy val asString: String = value.pctEncodeInclude(`gen-delims` -- charactersToIgnore)
+
+    /**
+      * @return the string representation using percent-encoding for the Fragment segment
+      *         when necessary according to rfc3986
+      */
+    lazy val pctEncoded: String = value.pctEncodeIgnore(charactersToIgnore)
+
+  }
 
   object Fragment {
 
@@ -1162,7 +1203,21 @@ object Iri {
     *
     * @param value the string value of the fragment
     */
-  final case class Nid private[rdf] (value: String) extends PctString
+  final case class Nid private[rdf] (value: String) {
+    private val charactersToIgnore = alpha ++ numeric + '/'
+
+    /**
+      * @return the string representation for the Nid segment compatible with the rfc3987
+      *         (using percent-encoding only for delimiters)
+      */
+    lazy val asString: String = value.pctEncodeInclude(`gen-delims` -- charactersToIgnore)
+
+    /**
+      * @return the string representation using percent-encoding for the Nid segment
+      *         when necessary according to rfc3986
+      */
+    lazy val pctEncoded: String = value.pctEncodeIgnore(charactersToIgnore)
+  }
 
   object Nid {
 
@@ -1182,7 +1237,21 @@ object Iri {
   /**
     * Urn R or Q component as defined by RFC 8141.
     */
-  final case class Component private[rdf] (value: String) extends PctString
+  final case class Component private[rdf] (value: String) {
+    private val charactersToIgnore = pchar + '/' + '?'
+
+    /**
+      * @return the string representation for the Component segment compatible with the rfc3987
+      *         (using percent-encoding only for delimiters)
+      */
+    lazy val asString: String = value.pctEncodeInclude(`gen-delims` -- charactersToIgnore)
+
+    /**
+      * @return the string representation using percent-encoding for the Component segment
+      *         when necessary according to rfc3986
+      */
+    lazy val pctEncoded: String = value.pctEncodeIgnore(charactersToIgnore)
+  }
 
   object Component {
 
@@ -1249,7 +1318,7 @@ object Iri {
     final def apply(string: String): Either[String, Urn] =
       new IriParser(string).parseUrn
 
-    final implicit val urnShow: Show[Urn] = Show.show(_.asUri)
+    final implicit val urnShow: Show[Urn] = Show.show(_.asString)
 
     final implicit val urnEq: Eq[Urn] = Eq.fromUniversalEquals
   }

--- a/src/main/scala/ch/epfl/bluebrain/nexus/rdf/PctString.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/rdf/PctString.scala
@@ -12,8 +12,10 @@ object PctString {
 
   private[rdf] def pctEncodedIgnore(s: String, toIgnore: Set[Char]) =
     s.foldLeft(new StringBuilder()) {
-        case (sb, b) if toIgnore.contains(b) => sb.append(b)
-        case (sb, b)                         => pctEncode(sb, b)
+        case (sb, b) if toIgnore.contains(b) =>
+          sb.append(b)
+        case (sb, b)                         =>
+          pctEncode(sb, b)
       }
       .toString()
 

--- a/src/main/scala/ch/epfl/bluebrain/nexus/rdf/PctString.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/rdf/PctString.scala
@@ -1,42 +1,29 @@
 package ch.epfl.bluebrain.nexus.rdf
+import java.net.URLEncoder
 import java.nio.charset.StandardCharsets.UTF_8
 
-import ch.epfl.bluebrain.nexus.rdf.PctString._
-import org.parboiled2.CharUtils.upperHexDigit
-
-trait PctString {
-
-  def value: String
-
-  /**
-    * @return the UTF-8 representation
-    */
-  lazy val asString: String =
-    value
-
-  /**
-    * @return the string representation using percent-encoding for any character that
-    *         is not contained in the Set ''pchar''
-    */
-  lazy val pctEncoded: String =
-    pctEncode(value)
-}
 object PctString {
+  private[rdf] val `sub-delims` = Set('!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=')
+  private[rdf] val alpha        = ('a' to 'z').toSet ++ ('A' to 'Z').toSet
+  private[rdf] val numeric      = ('0' to '9').toSet
+  private[rdf] val unreserved   = Set('-', '_', '.', '~') ++ alpha ++ numeric
+  private[rdf] val pchar        = `sub-delims` ++ unreserved + ':' + '@'
+  private[rdf] val `gen-delims` = Set(':', '/', '?', '#', '[', ']', '@')
 
-  private[rdf] val `sub-delims` = Set('!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=').map(_.toByte)
-  private[rdf] val unreserved = Set('-', '_', '.', '~').map(_.toByte) ++ ('a' to 'z')
-    .map(_.toByte)
-    .toSet ++ ('A' to 'Z')
-    .map(_.toByte)
-    .toSet ++ ('0' to '9').map(_.toByte).toSet
-  private[rdf] val pchar = `sub-delims` ++ unreserved + ':'.toByte + '@'.toByte
-
-  private[rdf] def pctEncode(s: String) = {
-    val in = s.getBytes(UTF_8)
-    in.foldLeft(new StringBuilder()) {
-        case (sb, b) if pchar.contains(b) => sb.append(b.toChar)
-        case (sb, b)                      => sb.append("%").append(upperHexDigit((b >> 4) & 0xF)).append(upperHexDigit(b & 0xF))
+  private[rdf] def pctEncodedIgnore(s: String, toIgnore: Set[Char]) =
+    s.foldLeft(new StringBuilder()) {
+        case (sb, b) if toIgnore.contains(b) => sb.append(b)
+        case (sb, b)                         => pctEncode(sb, b)
       }
       .toString()
-  }
+
+  private[rdf] def pctEncodedInclude(s: String, toEncode: Set[Char]) =
+    s.foldLeft(new StringBuilder()) {
+        case (sb, b) if toEncode.contains(b) => pctEncode(sb, b)
+        case (sb, b)                         => sb.append(b)
+      }
+      .toString()
+
+  private def pctEncode(sb: StringBuilder, char: Char): StringBuilder =
+    sb.append(URLEncoder.encode(char.toString, UTF_8.displayName()))
 }

--- a/src/main/scala/ch/epfl/bluebrain/nexus/rdf/syntax/StringEncodingSyntax.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/rdf/syntax/StringEncodingSyntax.scala
@@ -1,0 +1,11 @@
+package ch.epfl.bluebrain.nexus.rdf.syntax
+
+import ch.epfl.bluebrain.nexus.rdf.PctString.{pctEncodedIgnore, pctEncodedInclude}
+
+trait StringEncodingSyntax {
+  implicit final def stringSyntax(value: String): StringEncodingOpts = new StringEncodingOpts(value)
+}
+final class StringEncodingOpts(private val value: String) extends AnyVal {
+  def pctEncodeInclude(toEncode: Set[Char]): String = pctEncodedInclude(value, toEncode)
+  def pctEncodeIgnore(toIgnore: Set[Char]): String  = pctEncodedIgnore(value, toIgnore)
+}

--- a/src/main/scala/ch/epfl/bluebrain/nexus/rdf/syntax/package.scala
+++ b/src/main/scala/ch/epfl/bluebrain/nexus/rdf/syntax/package.scala
@@ -6,3 +6,4 @@ package object syntax
     with GraphDecoderSyntax
     with NodeSyntax
     with NodeUnsafeSyntax
+    with StringEncodingSyntax

--- a/src/test/scala/ch/epfl/bluebrain/nexus/rdf/CurieSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/rdf/CurieSpec.scala
@@ -65,7 +65,7 @@ class CurieSpec extends WordSpecLike with Matchers with Inspectors with EitherVa
           val curie = Curie(in).right.value
           curie.prefix.value shouldEqual p
           curie.reference.asString shouldEqual r
-          curie.show shouldEqual s"$p:${curie.reference.asUri}"
+          curie.show shouldEqual s"$p:${curie.reference.asString}"
       }
     }
 

--- a/src/test/scala/ch/epfl/bluebrain/nexus/rdf/FragmentSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/rdf/FragmentSpec.scala
@@ -23,7 +23,13 @@ class FragmentSpec extends WordSpecLike with Matchers with Inspectors with Eithe
     }
 
     "show" in {
-      Fragment(pct + ucs + delims + rest).right.value.show shouldEqual ucs + ucs + delims + rest
+      val encodedDelims = urlEncode("#[]")
+      Fragment(pct + ucs + delims + rest + encodedDelims).right.value.show shouldEqual ucs + ucs + delims + rest + encodedDelims
+    }
+
+    "pct encoded representation" in {
+      val encodedDelims = urlEncode("#[]")
+      Fragment(pct + ucs + delims + rest + encodedDelims).right.value.pctEncoded shouldEqual pct + pct + delims + rest + encodedDelims
     }
 
     "eq" in {

--- a/src/test/scala/ch/epfl/bluebrain/nexus/rdf/HostSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/rdf/HostSpec.scala
@@ -118,6 +118,8 @@ class HostSpec extends WordSpecLike with Matchers with Inspectors with EitherVal
   "A NamedHost" should {
     val pct =
       "%C2%A3%C2%A4%C2%A5%C2%A6%C2%A7%C2%A8%C2%A9%C2%AA%C2%AB%C2%AC%C2%AD%C2%AE%C2%AF%C2%B0%C2%B1%C2%B2%C2%B3%C2%B4%C2%B5%C2%B6%C2%B7%C2%B8%C2%B9%C2%BA%C2%BB%C2%BC%C2%BD%C2%BE%C2%BF%C3%80%C3%81%C3%82%C3%83%C3%84%C3%85%C3%86"
+    val pctLow =
+      "%C2%A3%C2%A4%C2%A5%C2%A6%C2%A7%C2%A8%C2%A9%C2%AA%C2%AB%C2%AC%C2%AD%C2%AE%C2%AF%C2%B0%C2%B1%C2%B2%C2%B3%C2%B4%C2%B5%C2%B6%C2%B7%C2%B8%C2%B9%C2%BA%C2%BB%C2%BC%C2%BD%C2%BE%C2%BF%C3%A0%C3%A1%C3%A2%C3%A3%C3%A4%C3%A5%C3%A6"
     val ucsUp  = "£¤¥¦§¨©ª«¬\u00AD®¯°±²³´µ¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆ"
     val ucsLow = "£¤¥¦§¨©ª«¬\u00AD®¯°±²³´µ¶·¸¹º»¼½¾¿àáâãäåæ"
     val delims = "!$&'()*+,;="
@@ -145,7 +147,13 @@ class HostSpec extends WordSpecLike with Matchers with Inspectors with EitherVal
     }
 
     "show" in {
-      Host.named(up).right.value.show shouldEqual low
+      val encodedDelim = urlEncode("[]#")
+      Host.named(up + encodedDelim).right.value.show shouldEqual (low + encodedDelim)
+    }
+
+    "pct encoded representation" in {
+      val encodedDelim = urlEncode("[]#")
+      Host.named(ucsUp + pct + ucsLow + delims + up + encodedDelim).right.value.pctEncoded shouldEqual (pctLow + pctLow + pctLow + delims + low+ encodedDelim)
     }
 
     "be named" in {

--- a/src/test/scala/ch/epfl/bluebrain/nexus/rdf/IriSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/rdf/IriSpec.scala
@@ -1,7 +1,6 @@
 package ch.epfl.bluebrain.nexus.rdf
 
 import cats.kernel.Eq
-import cats.syntax.show._
 import ch.epfl.bluebrain.nexus.rdf.Iri._
 import org.scalatest.{EitherValues, Inspectors, Matchers, WordSpecLike}
 
@@ -28,7 +27,8 @@ class IriSpec extends WordSpecLike with Matchers with Inspectors with EitherValu
       "hTtps://me:me@hOst:443/a/b?a&e=f&b=c#frag"                                                  -> "https://me:me@host/a/b?a&b=c&e=f#frag",
       "hTtps://me:me@hOst#frag"                                                                    -> "https://me:me@host#frag",
       "hTtp://hOst%C2%A3:80/a%C2%A3/b%C3%86c//:://"                                                -> "http://host£/a£/bÆc//:://",
-      "https://my%40user:my%3Apassword%24@myhost.com/a/path/http%3A%2F%2Fexample.com%2Fnxv%3Asome" -> "https://my%40user:my:password$@myhost.com/a/path/http:%2F%2Fexample.com%2Fnxv:some"
+      "https://my%40user:my%3Apassword%24@myhost.com/a/path/http%3A%2F%2Fexample.com%2Fnxv%3Asome" -> "https://my%40user:my:password$@myhost.com/a/path/http:%2F%2Fexample.com%2Fnxv:some",
+      "http://abc%40:def@example.com/a/http%3A%2F%2Fother.com"                                     -> "http://abc%40:def@example.com/a/http:%2F%2Fother.com"
     )
 
     val casesUrlEncoded = List(
@@ -62,24 +62,24 @@ class IriSpec extends WordSpecLike with Matchers with Inspectors with EitherValu
       }
     }
 
-    "show url" in {
+    "show as url" in {
       forAll(casesUrlEncoded) {
         case (in, expected) =>
-          Iri(in).right.value.show shouldEqual expected
+          Iri(in).right.value.asUri shouldEqual expected
       }
     }
 
-    "show urn" in {
+    "show as uri" in {
       forAll(casesUrnEncoded) {
         case (in, expected) =>
-          Iri(in).right.value.show shouldEqual expected
+          Iri(in).right.value.asUri shouldEqual expected
       }
     }
 
-    "show relative url" in {
+    "show as relative uri" in {
       forAll(casesRelativeEncoded) {
         case (in, expected) =>
-          Iri(in).right.value.show shouldEqual expected
+          Iri(in).right.value.asUri shouldEqual expected
       }
     }
 

--- a/src/test/scala/ch/epfl/bluebrain/nexus/rdf/PathSpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/rdf/PathSpec.scala
@@ -2,7 +2,7 @@ package ch.epfl.bluebrain.nexus.rdf
 
 import cats.kernel.Eq
 import cats.syntax.show._
-import ch.epfl.bluebrain.nexus.rdf.Iri.Path.{segment, _}
+import ch.epfl.bluebrain.nexus.rdf.Iri.Path._
 import ch.epfl.bluebrain.nexus.rdf.Iri._
 import org.scalatest.{EitherValues, Inspectors, Matchers, WordSpecLike}
 
@@ -72,7 +72,15 @@ class PathSpec extends WordSpecLike with Matchers with Inspectors with EitherVal
       }
     }
     "show" in {
-      abcd.right.value.show shouldEqual "/a/b//c/d"
+      val encodedDelims = urlEncode("/#[]?")
+      Path("/" + encodedDelims + "/a/b//c/d/£¤¥").right.value.show shouldEqual "/" + encodedDelims + "/a/b//c/d/£¤¥"
+    }
+    "pct encoded representation" in {
+      val encodedDelims = urlEncode("/#[]?")
+      val utf8          = "£¤¥"
+      val utf8Encoded   = urlEncode(utf8)
+      Path("/" + encodedDelims + "/a/b//c/d/" + utf8 + "/" + utf8Encoded).right.value.pctEncoded shouldEqual
+        "/" + encodedDelims + "/a/b//c/d/" + utf8Encoded + "/" + utf8Encoded
     }
     "be slash" in {
       Path("/").right.value.isSlash shouldEqual true

--- a/src/test/scala/ch/epfl/bluebrain/nexus/rdf/QuerySpec.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/rdf/QuerySpec.scala
@@ -38,7 +38,15 @@ class QuerySpec extends WordSpecLike with Matchers with Inspectors with EitherVa
       }
     }
     "show" in {
-      Query("a=b&a=b&a=c&a&b&b&b=c&d&e").right.value.show shouldEqual "a&a=b&a=c&b&b=c&d&e"
+      val encodedDelim = urlEncode("[]#")
+      Query("a=b&a=b&a=c&a&b&b&b=c&d&e" + encodedDelim).right.value.show shouldEqual "a&a=b&a=c&b&b=c&d&e" + encodedDelim
+    }
+    "pct encoded representation" in {
+      val utf8         = "£Æ"
+      val encodedUtf8  = urlEncode(utf8)
+      val allowedDelim = "!:@!$()+*,"
+      val encodedDelim = urlEncode("[]#")
+      Query(utf8 + encodedUtf8 + allowedDelim + encodedDelim).right.value.pctEncoded shouldEqual (encodedUtf8 + encodedUtf8 + allowedDelim + encodedDelim)
     }
     "eq" in {
       val lhs = Query("a=b&a=b&a=c&a&b&b&b=c&d&e").right.value

--- a/src/test/scala/ch/epfl/bluebrain/nexus/rdf/package.scala
+++ b/src/test/scala/ch/epfl/bluebrain/nexus/rdf/package.scala
@@ -1,0 +1,8 @@
+package ch.epfl.bluebrain.nexus
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets.UTF_8
+
+package object rdf {
+  def urlEncode(s: String): String = URLEncoder.encode(s, UTF_8.displayName())
+}


### PR DESCRIPTION
- `.asString` and `.show` will output the Iri compatible representation (delimiters of each segment are percent-encoded) - RFC 3987
- `.asUri` will output the Uri compatible representation (non-ASCII & delimiter characters are percent-encoded) - RFC 3986 / RFC 8141